### PR TITLE
chore: init tiptap editor component for node detail

### DIFF
--- a/src/app/roadmap/editor/page.tsx
+++ b/src/app/roadmap/editor/page.tsx
@@ -1,0 +1,1 @@
+export default function EditPage() {}

--- a/src/app/roadmap/post/components/roadmapInfo/TiptapEditor.tsx
+++ b/src/app/roadmap/post/components/roadmapInfo/TiptapEditor.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { Highlight } from '@tiptap/extension-highlight';
+import { Link } from '@tiptap/extension-link';
+import { Subscript } from '@tiptap/extension-subscript';
+import { Superscript } from '@tiptap/extension-superscript';
+import { TextAlign } from '@tiptap/extension-text-align';
+import { Underline } from '@tiptap/extension-underline';
+import Youtube from '@tiptap/extension-youtube';
+import { EditorContent, useEditor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+const NodeDetails = () => {
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      Youtube.configure({
+        inline: false,
+        ccLanguage: 'ko',
+        interfaceLanguage: 'ko',
+      }),
+      Underline,
+      Link,
+      Superscript,
+      Subscript,
+      Highlight,
+      TextAlign.configure({ types: ['heading', 'paragraph'] }),
+    ],
+    editable: false,
+    // content: state.filter((v) => v.id === id)[0]?.details || '',
+    // onUpdate(e) {
+    //   setToggle(e.editor?.getHTML());
+    // eslint-disable-next-line array-callback-return
+    //   state.forEach((item, idx) => {
+    // if (item.id !== id) return;
+    // const copyState = [...state];
+    // copyState.splice(idx, 1, {
+    //   id: item.id,
+    //   details: e.editor?.getHTML(),
+    // });
+    // setState(copyState);
+    //   });
+    // },
+  });
+  return (
+    <EditorContent editor={editor} readOnly style={{ lineHeight: '2rem' }} />
+  );
+};
+export default NodeDetails;

--- a/src/app/roadmap/post/components/roadmapInfo/reactFlow/ReactFlow.tsx
+++ b/src/app/roadmap/post/components/roadmapInfo/reactFlow/ReactFlow.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { PropsWithChildren, useEffect } from 'react';
+import ReactFlow, {
+  Edge,
+  Node,
+  ReactFlowProvider,
+  useEdgesState,
+  useNodesState,
+} from 'reactflow';
+import styled from 'styled-components';
+
+import 'reactflow/dist/style.css';
+
+import { ReactFlowInfo } from '@/app/roadmap/post/components/roadmapInfo';
+import TipTapEditor from '@/app/roadmap/post/components/roadmapInfo/TiptapEditor';
+
+import CustomEdge from './custom/BezierEdge';
+import { DoneStatusNode } from './custom/DoneStatusNode';
+
+interface ReactFlowProps extends PropsWithChildren {
+  reactFlowInfo: ReactFlowInfo;
+}
+
+const proOptions = { hideAttribution: true };
+
+const ReactFlowRoadmap = ({ reactFlowInfo }: ReactFlowProps) => {
+  const { nodes, edges } = reactFlowInfo;
+
+  const [nodeState, setNodes, onNodesChange] = useNodesState<Node[]>([]);
+  const [edgeState, setEdges, onEdgesChange] = useEdgesState<Edge[]>([]);
+
+  const getMinMax = <T extends ReactFlowInfo['nodes']>(obj: T, arg: string) =>
+    obj.reduce(
+      (acc, curr) => {
+        const currVal = arg === 'height' ? curr.position.y : curr.position.x;
+        if (Math.min(acc.min, currVal) === currVal) acc.min = currVal;
+        if (Math.max(acc.max, currVal) === currVal) acc.max = currVal;
+        return acc;
+      },
+      { max: -Infinity, min: Infinity },
+    );
+
+  const getHeight = getMinMax(nodes, 'height');
+  const getWidth = getMinMax(nodes, 'width');
+
+  const getRangePx = (obj: { max: number; min: number }, offset: number) =>
+    `${obj.max + obj.min + offset}px`;
+
+  const nodeTypes = { custom: DoneStatusNode };
+
+  const edgeTypes = {
+    smoothstep: CustomEdge,
+  };
+
+  useEffect(() => {
+    const customNodes = nodes as unknown as Node<Node[], string | undefined>[];
+    const customEdges = edges as unknown as Edge<Edge[]>[];
+    setNodes(customNodes);
+    setEdges(customEdges);
+  }, [nodes, edges, setEdges, setNodes]);
+
+  return (
+    <Wrap
+      style={{
+        height: `${getRangePx(getHeight, 300)}`,
+        width: `${getRangePx(getWidth, 396)}`,
+        padding: '1rem',
+        overflowX: 'visible',
+      }}
+    >
+      <ReactFlowProvider>
+        <ReactFlow
+          preventScrolling={false}
+          nodes={nodeState}
+          nodeTypes={nodeTypes}
+          edges={edgeState}
+          edgeTypes={edgeTypes}
+          proOptions={proOptions}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          elementsSelectable={true}
+          nodesConnectable={false}
+          nodesDraggable={false}
+          zoomOnScroll={false}
+          panOnScroll={false}
+          zoomOnDoubleClick={false}
+          panOnDrag={false}
+          attributionPosition='top-right'
+        ></ReactFlow>
+        <TipTapEditor />
+      </ReactFlowProvider>
+    </Wrap>
+  );
+};
+
+const Wrap = styled.div`
+  .react-flow__node.react-flow__node-custom {
+    max-width: 15rem !important;
+    width: fit-content !important;
+
+    :hover {
+      cursor: pointer;
+    }
+  }
+`;
+export default ReactFlowRoadmap;


### PR DESCRIPTION
# Description & Technical Solution

- useQuery를 통해 로드맵에 대한 데이터를 fetch 하고 About의 각 컴포넌트에 props 전달을 했습니다.
- pick , omit 유틸 함수를  통해 객체의 필요 데이터만 선택하여 컴포넌트에 전달하도록 했습니다.

```tsx
const loadDataFromApi = async (pageParam: string) => {
  const [roadMapInfo] = await Promise.all([
    getApiResponse<RoadMapInfo>({
      apiEndpoint: `${process.env.NEXT_PUBLIC_API}/roadmaps/${pageParam}`,
      revalidate: 60 * 2, // 5 mins cache
    }),
  ]);

  return {
    roadMapInfo,
  };
};

const Roadmap = ({ params }: { params: { id: string } }) => {
  const { id } = params;
  const { data, isLoading, isError, isSuccess } = useQuery({
    queryKey: [`post${id}`],
    queryFn: async () => await loadDataFromApi(id),
  });

  if (isLoading) return <div>is loading</div>;
  if (isError) return <div>oops something went wrong!🥲</div>;
  if (data === null || !data?.roadMapInfo) {
    return (
      <main>
        <section>
          <div>empty</div>
        </section>
      </main>
    );
  }

```

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.



# Related issue

- Resolve #4