### PR TITLE
I4 add roadmap node detail content with tiptap editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@tiptap/extension-subscript": "^2.2.4",
     "@tiptap/extension-superscript": "^2.2.4",
     "@tiptap/extension-text-align": "^2.2.4",
+    "@tiptap/extension-text-style": "^2.2.4",
     "@tiptap/extension-underline": "^2.2.4",
     "@tiptap/extension-youtube": "^2.2.4",
     "@tiptap/pm": "^2.2.4",

--- a/src/app/roadmap/post/components/roadmapInfo/reactFlow/nodeDetail/TiptapEditor.tsx
+++ b/src/app/roadmap/post/components/roadmapInfo/reactFlow/nodeDetail/TiptapEditor.tsx
@@ -5,14 +5,24 @@ import { Link } from '@tiptap/extension-link';
 import { Subscript } from '@tiptap/extension-subscript';
 import { Superscript } from '@tiptap/extension-superscript';
 import { TextAlign } from '@tiptap/extension-text-align';
+import TextStyle from '@tiptap/extension-text-style';
 import { Underline } from '@tiptap/extension-underline';
 import Youtube from '@tiptap/extension-youtube';
 import { EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
-const NodeDetails = () => {
+import { PropsWithChildren, useMemo } from 'react';
+
+import { DetailedContent } from '../ReactFlow';
+
+export interface NodeDetailsProps extends PropsWithChildren {
+  details: DetailedContent;
+}
+
+const NodeDetails = ({ details }: NodeDetailsProps) => {
   const editor = useEditor({
     extensions: [
       StarterKit,
+      TextStyle,
       Youtube.configure({
         inline: false,
         ccLanguage: 'ko',
@@ -23,10 +33,16 @@ const NodeDetails = () => {
       Superscript,
       Subscript,
       Highlight,
-      TextAlign.configure({ types: ['heading', 'paragraph'] }),
+      TextAlign.configure({ types: ['heading', 'paragraph', ''] }),
     ],
     editable: false,
+    content: details.detailedContent,
   });
+
+  useMemo(() => {
+    editor?.commands.setContent(details.detailedContent);
+  }, [details, editor?.commands]);
+
   return (
     <EditorContent editor={editor} readOnly style={{ lineHeight: '2rem' }} />
   );

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -61,7 +61,6 @@ export default function Mainpage() {
     error,
     fetchNextPage,
     hasNextPage,
-    isFetchingNextPage,
     isError,
     status,
   } = useInfiniteQuery({
@@ -90,10 +89,6 @@ export default function Mainpage() {
         oops something went wrong😑{status}, {error}
       </>
     );
-  }
-
-  if (isFetchingNextPage) {
-    return <>fetching next page</>;
   }
 
   if (posts)

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -7,6 +7,6 @@ export const GlobalStyle = createGlobalStyle`
 	${reset}
 	body{
 		background-color: ${({ theme }) => theme.white};
-		color: ${({ theme }) => theme.colors.color_primary};
+		/* color: ${({ theme }) => theme.colors.color_primary}; */
 	}
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,6 +2225,11 @@
   resolved "https://registry.yarnpkg.com/@tiptap/extension-text-align/-/extension-text-align-2.2.4.tgz#db63ca334e3d5512a67652e393ed9ee982d78b6a"
   integrity sha512-iojhpsv3n/r4g/4wMFl1d85RloWrAV3TRUJluurPQZJdrJ7ynJ2fiPqmigAXyaYAJ3+a1ryu9JPlktT9RdYO/A==
 
+"@tiptap/extension-text-style@^2.2.4":
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-text-style/-/extension-text-style-2.2.4.tgz#078f7fc1712e1b0ac7b6597156b8a9bf12a5eaab"
+  integrity sha512-8Mcxy+HUHPUgK7bOv34m8zhbhzPm6f1/hgbgwz9m+Oel7MNPElsMXtxxygbwtr7Hbj6S4NBoBl/Ir4BkziYRbQ==
+
 "@tiptap/extension-text@^2.2.4":
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/@tiptap/extension-text/-/extension-text-2.2.4.tgz#aa101c568aa78a4ddc06a944eefcd3ac944987d4"


### PR DESCRIPTION
# Description & Technical Solution

- #10 : 메인 페이지에서 스크롤할 때 스크롤 위치가 맨 위로 다시 올라가는 문제가 발견되었습니다. 해당 문제는 [isFetching에서 fetch 시 전체 컴포넌트를 unmount](https://github.com/TanStack/query/issues/3363)하기 때문에
 제거했습니다.

- tiptap 에디터를 통해 작성했던 노드 상세 내용을 보이도록 했습니다.
- string을 html로 바꾸기 위해 리액트에서는  XXS(교차 사이트 스크립팅) 공격의 위험성이 있어 [dangerouslySetInnerHTML](https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml)을 적용하려 했으나, 라이브러리 내부의 함수 `editor?.commands.setContent()`을 활용했습니다.
- 선택한 노드에 따라 상세 내용이 mantine Drawer에 보이도록했습니다.
- 노드에 따라 내용이 변경되도록 `useMemo`에 노드 데이터 (details)값을 의존성 배열에 추가했습니다.
- ‼️ ISSUE: 태그가 반영이 안되고 있어요‼️
   - 아래와 같이 h1 태그인데 폰트 크기가 p 태그와 동일한 문제를 해결해야 합니다.
   
<img width="446" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/569622ca-e2aa-40ab-a0a0-784406d3d84f">
  

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

