### PR TITLE
13 add fetched comments in roadmap page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@
 > 이 레포지터리는 `NEXT14`로 [로드메이커 프로젝트](https://github.com/road-maker/road-maker-react-typescript/tree/master)를 마이그레이션한 프로젝트입니다.
 
 ## 진행 과정
+
+https://github.com/users/Pyotato/projects/9

--- a/src/app/roadmap/post/components/comment/Comments.tsx
+++ b/src/app/roadmap/post/components/comment/Comments.tsx
@@ -2,6 +2,7 @@
 
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
+import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import { CommentHtml } from '@/components/shared/list/CommentHtml';
@@ -43,9 +44,9 @@ const Comments = () => {
   const {
     data: comments,
     error,
-    // !!CONF need to update api :currently fetching all data
-    // fetchNextPage,
-    // hasNextPage,
+    // !!API need to update api :currently fetching all data
+    fetchNextPage,
+    hasNextPage,
     isError,
     status,
   } = useInfiniteQuery({
@@ -59,6 +60,12 @@ const Comments = () => {
     },
   });
 
+  useEffect(() => {
+    if (inView && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, fetchNextPage, hasNextPage]);
+
   if (isError)
     return (
       <>
@@ -70,7 +77,11 @@ const Comments = () => {
     return (
       <>
         {comments.pages.map(({ comments }, i) => (
-          <CommentHtml key={i} commentData={comments?.result || []} />
+          <CommentHtml
+            key={i}
+            commentData={comments?.result || []}
+            innerRef={ref}
+          />
         ))}
       </>
     );


### PR DESCRIPTION
# Description & Technical Solution

- 이전 로드메이커에서는 단순 textInput으로 댓글을 작성하도록 했습니다.
- 현재는 Tiptap editor RichTextEditor를 통해 html content를 작성할 수 있도록 했습니다.

- ‼️ ISSUES ‼️ 
  -  #13 에서 useInfiniteQuery를 적용하여 스크롤할 경우 5개의 댓글을 fetch하는 로직을 구현했습니다.
  -  하지만 현재 api 쪽에서는 5개의 댓글이 아닌 전체 댓글을 한번에 보내기 때문에 현재는 전체 댓글을 불러오는 식으로 동작합니다.
  -댓글 달기 후 새 댓글이 바로 보이지 않고  (전체 컴포넌트를 unmount하고 fetch하기 떄문) 새로고침을 해야만 새로 등록한 댓글이 보입니다. 
- 따라서 #22 에서 새로운 이슈를 생성했습니다.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

## Screenshots

<img width="453" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/5335cba4-7172-4753-be45-453a8d934897">

<img width="453" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/0bfb1d23-02d6-40d5-a63a-9a57a035db4b">
