### PR TITLE
15 style roadmap detailpage

### DIFF
--- a/src/app/roadmap/post/[[...id]]/page.tsx
+++ b/src/app/roadmap/post/[[...id]]/page.tsx
@@ -1,3 +1,5 @@
+import { Container } from '@mantine/core';
+
 import Roadmap from '@/app/roadmap/post/components/roadmapInfo';
 
 import CommentSection from '../components/comment';
@@ -6,7 +8,9 @@ export default function PostPage({ params }: { params: { id: string } }) {
   return (
     <div>
       <Roadmap params={params} />
-      <CommentSection />
+      <Container py='xl'>
+        <CommentSection />
+      </Container>
     </div>
   );
 }

--- a/src/app/roadmap/post/components/roadmapInfo/index.tsx
+++ b/src/app/roadmap/post/components/roadmapInfo/index.tsx
@@ -117,7 +117,17 @@ const Roadmap = ({ params }: { params: { id: string } }) => {
     return (
       <>
         <About aboutInfo={aboutInfo} />
-        <ReactFlow reactFlowInfo={reactFlowInfo} />
+        <div
+          style={{
+            display: 'inline-flex',
+            minWidth: '100%',
+            width: 'fit-content',
+            justifyContent: 'center',
+            backgroundColor: '#EFEFEF',
+          }}
+        >
+          <ReactFlow reactFlowInfo={reactFlowInfo} />
+        </div>
       </>
     );
   }

--- a/src/app/roadmap/post/components/roadmapInfo/reactFlow/ReactFlow.tsx
+++ b/src/app/roadmap/post/components/roadmapInfo/reactFlow/ReactFlow.tsx
@@ -54,7 +54,7 @@ const ReactFlowRoadmap = ({ reactFlowInfo }: ReactFlowProps) => {
   const getWidth = getMinMax(nodes, 'width');
 
   const getRangePx = (obj: { max: number; min: number }, offset: number) =>
-    `${obj.max + obj.min + offset}px`;
+    `${obj.max - obj.min + offset}px`;
 
   const nodeTypes = useMemo(() => ({ custom: DoneStatusNode }), []);
 
@@ -81,6 +81,7 @@ const ReactFlowRoadmap = ({ reactFlowInfo }: ReactFlowProps) => {
     >
       <ReactFlowProvider>
         <ReactFlow
+          fitView
           preventScrolling={false}
           nodes={nodeState}
           nodeTypes={nodeTypes}
@@ -114,7 +115,7 @@ const ReactFlowRoadmap = ({ reactFlowInfo }: ReactFlowProps) => {
           lockScroll={false}
         >
           <Drawer.Content>
-            <Drawer.CloseButton mr='1rem' mt='1rem' />
+            <Drawer.CloseButton mr='1rem' mt='1rem' ml='1rem' />
             <Drawer.Body p='1rem' style={{ height: '100vh' }}>
               <NodeDetails details={openNode} />
             </Drawer.Body>

--- a/src/components/shared/list/CommentHtml.tsx
+++ b/src/components/shared/list/CommentHtml.tsx
@@ -20,7 +20,8 @@ export interface CommentProps extends PropsWithChildren {
 }
 
 export function CommentHtml({ commentData, innerRef }: CommentProps) {
-  if (!commentData.length) return <>아직 댓글이 없습니다.</>;
+  if (!commentData.length)
+    return <Container my='xl'>아직 댓글이 없습니다.</Container>;
 
   const comments = commentData.map((v, i) =>
     i === commentData.length - 1 ? (


### PR DESCRIPTION
# Description & Technical Solution

- `fitView`설정을 통해 가운데로 viewport가 맞춰지도록 했습니다.
- 로드맵 여백을 추가하는 코드에서 최대와 최소값의 차를 구해야 width가 구해지기 때문에 수정했습니다.
- ‼️ ISSUE ‼️
  -아래와 같이 특정 포스트에 데이터가 없을 때만 보이는 요소가 나오는 버그를 해결해야 합니다.
<img width="1084" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/89360893-daff-4e7e-9f9a-018c3ebf5f35">

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

## Screenshots

<img width="1084" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/4227172d-b2dc-4cd0-8e8c-f79a93026f24">

<img width="1084" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/fe738fc8-38a5-42c1-9f9e-06fe68b130f0">

<img width="1084" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/e899636a-9ddb-400c-abec-fb3c426b0846">
