### PR TITLE
25 fix no content elem showing when elem exists

### DIFF
--- a/src/app/roadmap/post/components/comment/Comments.tsx
+++ b/src/app/roadmap/post/components/comment/Comments.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Container } from '@mantine/core';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
 import { useEffect } from 'react';
@@ -41,10 +42,11 @@ const Comments = () => {
     };
   };
 
+  // !!API need to update api :currently fetching all data
+
   const {
     data: comments,
     error,
-    // !!API need to update api :currently fetching all data
     fetchNextPage,
     hasNextPage,
     isError,
@@ -73,17 +75,24 @@ const Comments = () => {
       </>
     );
 
-  if (comments)
+  if (comments) {
+    if (comments.pages[0].comments?.totalPage === 0)
+      return <Container my='xl'>아직 댓글이 없습니다.</Container>;
     return (
       <>
-        {comments.pages.map(({ comments }, i) => (
-          <CommentHtml
-            key={i}
-            commentData={comments?.result || []}
-            innerRef={ref}
-          />
-        ))}
+        {comments.pages.map(({ comments }, i) =>
+          comments?.next ? (
+            <CommentHtml
+              key={i}
+              commentData={comments?.result || []}
+              innerRef={ref}
+            />
+          ) : (
+            <CommentHtml key={i} commentData={comments?.result || []} />
+          ),
+        )}
       </>
     );
+  }
 };
 export default Comments;

--- a/src/components/shared/list/CommentHtml.tsx
+++ b/src/components/shared/list/CommentHtml.tsx
@@ -30,6 +30,7 @@ export function CommentHtml({ commentData, innerRef }: CommentProps) {
         radius='md'
         className={classes.comment}
         key={i}
+        style={{ overflow: 'hidden' }}
         ref={innerRef}
       >
         <Group>
@@ -55,7 +56,13 @@ export function CommentHtml({ commentData, innerRef }: CommentProps) {
         </TypographyStylesProvider>
       </Paper>
     ) : (
-      <Paper withBorder radius='md' className={classes.comment} key={i}>
+      <Paper
+        withBorder
+        radius='md'
+        className={classes.comment}
+        key={i}
+        style={{ overflow: 'hidden' }}
+      >
         <Group>
           <Avatar
             src='https://raw.githubusercontent.com/mantinedev/mantine/master/.demo/avatars/avatar-2.png'

--- a/src/components/shared/list/CommentHtml.tsx
+++ b/src/components/shared/list/CommentHtml.tsx
@@ -20,8 +20,7 @@ export interface CommentProps extends PropsWithChildren {
 }
 
 export function CommentHtml({ commentData, innerRef }: CommentProps) {
-  if (!commentData.length)
-    return <Container my='xl'>아직 댓글이 없습니다.</Container>;
+  if (commentData.length === 0) return <></>;
 
   const comments = commentData.map((v, i) =>
     i === commentData.length - 1 ? (


### PR DESCRIPTION
# Description & Technical Solution

- #24 에서 댓글이 있는데 댓글이 없을 때만 보이는 요소가 있는 버그가 있었습니다.
- 해당 문제는  `comments.pages[0].comments?.totalPage`에서 페이지가 0일 때, 즉 아예 댓글이 달리지 않아 페이지가 없을 때 보이도록 early return을 하는 방식으로 해결했습니다.
- 기존의 comment이 담긴 배열(commentData)의 길이를 확인하는 코드에서  `if (commentData.length === 0) return <></>;`으로 변경하여 댓글이 없으면 배열을 순회하며 댓글 요소를 보이기 전에 early return 하도록 했습니다.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

## Screenshots

- 문제 해결 전: 댓글이 있는데 없다고 표시

<img width="600" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/e13b9482-2cba-4290-b1a0-b6e1c6058c0e">

- 문제 해결 후
  - 댓글이 있을 경우 
  <img width="1084" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/89360893-daff-4e7e-9f9a-018c3ebf5f35">
  - 댓글이 없을 경우
  <img width="600" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/f14c9773-7b3d-460e-bf2d-54afc7437f01">
