### PR TITLE
17 add roadmap create edit page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,10 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
 
+  compiler: {
+    styledComponents: true,
+  },
+
   // Uncoment to add domain whitelist
   // images: {
   //   domains: [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@mantine/charts": "^7.5.2",
     "@mantine/code-highlight": "^7.5.2",
     "@mantine/core": "^7.6.1",
-    "@mantine/dropzone": "^7.5.2",
+    "@mantine/dropzone": "^7.6.1",
     "@mantine/form": "^7.5.2",
     "@mantine/hooks": "^7.6.1",
     "@mantine/modals": "^7.5.2",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import '@mantine/core/styles.css';
 import '@mantine/tiptap/styles.css';
+import 'reactflow/dist/style.css';
 
 import PageFooter from '@/components/shared/layouts/PageFooter';
 import PageHeader from '@/components/shared/layouts/PageHeader';

--- a/src/app/roadmap/create/components/PanelControl.tsx
+++ b/src/app/roadmap/create/components/PanelControl.tsx
@@ -1,0 +1,203 @@
+// 'use client';
+import { ActionIcon, Image, SimpleGrid, Text, TextInput } from '@mantine/core';
+import { Dropzone, FileWithPath, IMAGE_MIME_TYPE } from '@mantine/dropzone';
+import {
+  IconBinaryTree,
+  IconFileCheck,
+  IconInfoCircle,
+  IconPlus,
+  IconSchema,
+} from '@tabler/icons-react';
+import { useRouter } from 'next/navigation';
+import { useCallback, useMemo, useState } from 'react';
+import { Edge, Node } from 'reactflow';
+
+import { omit } from '@/utils/shared';
+import { getApiResponse } from '@/utils/shared/get-api-response';
+
+import { CustomEdge, CustomNode } from '../../post/components/roadmapInfo';
+
+const PanelItem = ({
+  onAddNode,
+  nodes,
+  edges,
+}: {
+  nodes: Node[];
+  edges: Edge[];
+  onAddNode: () => void;
+}) => {
+  const router = useRouter();
+
+  const [files, setFiles] = useState<FileWithPath[]>([]);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  const [formData, setFormData] = useState<FormData | null>();
+
+  useMemo(() => {
+    const tempFormData = new FormData();
+    tempFormData.append('file', files[0]);
+    setFormData(tempFormData);
+  }, [files]);
+
+  const previews = files.map((file, index) => {
+    const imageUrl = URL.createObjectURL(file);
+    return (
+      <Image
+        key={index}
+        src={imageUrl}
+        alt={imageUrl}
+        onLoad={() => URL.revokeObjectURL(imageUrl)}
+      />
+    );
+  });
+
+  const onSubmitRoadmap = useCallback(async () => {
+    if (!formData || !files) {
+      alert('썸네일은 필수입니다.');
+      return;
+    }
+    const tempNodes = nodes.reduce((acc, curr) => {
+      const tempNodes = {
+        ...omit(
+          curr,
+          'dragging',
+          'selected',
+          'type',
+          'targetPosition',
+          'sourcePosition',
+        ),
+        blogKeyword: '',
+        detailedContent: '',
+        type: 'custom',
+        targetPosition: curr?.targetPosition || 'left',
+        sourcePosition: curr?.sourcePosition || 'right',
+        positionAbsolute: { x: curr.position.x, y: curr.position.y },
+      } as CustomNode;
+      if (acc.length !== 0) acc = [...acc, tempNodes];
+      else acc = [tempNodes];
+      return acc;
+    }, [] as CustomNode[]);
+
+    const tempEdges = edges.reduce((acc, curr) => {
+      const temp = {
+        ...omit(curr, 'type', 'style'),
+        type: 'smoothstep',
+      } as CustomEdge;
+      if (acc.length !== 0) acc = [...acc, temp];
+      else acc = [temp];
+      return acc;
+    }, [] as CustomEdge[]);
+
+    const [response] = await Promise.all([
+      getApiResponse<undefined>({
+        requestData: JSON.stringify({
+          roadmap: {
+            title: title,
+            description: description,
+          },
+          nodes: tempNodes,
+          edges: tempEdges,
+          viewport: { x: 0, y: 0, zoom: 0.45 },
+        }),
+        apiEndpoint: `${process.env.NEXT_PUBLIC_API}/roadmaps`,
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${process.env.NEXT_PUBLIC_USER_ACCESS_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+      }),
+    ]);
+    if (!response) {
+      alert('failed to create roadmap');
+      return;
+    }
+
+    await Promise.all([
+      getApiResponse<undefined>({
+        requestData: formData,
+        apiEndpoint: `${process.env.NEXT_PUBLIC_API}/roadmaps/${response}/thumbnails`,
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${process.env.NEXT_PUBLIC_USER_ACCESS_TOKEN}`,
+        },
+      }),
+      getApiResponse<undefined>({
+        requestData: JSON.stringify({}),
+        apiEndpoint: `${process.env.NEXT_PUBLIC_API}/roadmaps/${response}/join`,
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${process.env.NEXT_PUBLIC_USER_ACCESS_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+      }),
+      alert(`${response} 포스팅 성공!`),
+      router.replace(`/roadmap/post/${response}`),
+    ]);
+  }, [nodes, edges, files, title, description, formData, router]);
+  return (
+    <>
+      {/* <Tooltip label='tootip'>
+        <MyBadge color='red' />
+      </Tooltip> */}
+      {/* <Tooltip.Group openDelay={500} closeDelay={100}>
+        <Group justify='center'>
+          <Tooltip label='Tooltip 1'>
+            <Button>Button 1</Button>
+          </Tooltip>
+          <Tooltip label='Tooltip 2'>
+            <Button>Button 2</Button>
+          </Tooltip>
+          <Tooltip label='Tooltip 3'>
+            <Button>Button 3</Button>
+          </Tooltip>
+        </Group>
+      </Tooltip.Group> */}
+      <div style={{ backgroundColor: 'green', padding: '1rem' }}>
+        로드맵 제목 :{' '}
+        <TextInput
+          value={title}
+          onChange={(event) => setTitle(event.currentTarget.value)}
+        />
+        로드맵 설명 :{' '}
+        <TextInput
+          value={description}
+          onChange={(event) => setDescription(event.currentTarget.value)}
+        />
+      </div>
+      <div style={{ backgroundColor: 'red' }}>
+        <Dropzone
+          accept={IMAGE_MIME_TYPE}
+          onDrop={(e) => {
+            setFiles(e);
+          }}
+        >
+          <Text ta='center'>Drop images here</Text>
+        </Dropzone>
+
+        <SimpleGrid
+          cols={{ base: 1, sm: 4 }}
+          mt={previews.length > 0 ? 'xl' : 0}
+        >
+          {previews}
+        </SimpleGrid>
+      </div>
+      <ActionIcon variant='default'>
+        <IconSchema data-disabled size='1rem' />
+      </ActionIcon>
+      <ActionIcon variant='default'>
+        <IconBinaryTree data-disabled size='1rem' />
+      </ActionIcon>
+      <ActionIcon variant='default' onClick={onSubmitRoadmap}>
+        <IconFileCheck data-disabled size='1rem' />
+      </ActionIcon>
+      <ActionIcon variant='default'>
+        <IconInfoCircle data-disabled size='1rem' />
+      </ActionIcon>
+      <ActionIcon variant='default' onClick={onAddNode}>
+        <IconPlus data-disabled size='1rem' />
+      </ActionIcon>
+    </>
+  );
+};
+export default PanelItem;

--- a/src/app/roadmap/create/components/reactFlow/custom/TextUpdaterNode.tsx
+++ b/src/app/roadmap/create/components/reactFlow/custom/TextUpdaterNode.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { FormEvent, useCallback } from 'react';
+import { Handle, Node, Position } from 'reactflow';
+import styled from 'styled-components';
+
+function TextUpdaterNode({ data }: { data: Node['data'] }) {
+  const onChange = useCallback(
+    (evt: FormEvent<HTMLInputElement>) => {
+      data.label = evt?.currentTarget?.value;
+    },
+    [data],
+  );
+
+  return (
+    <Wrap className='text-updater-node'>
+      <Handle
+        type='target'
+        position={Position.Right}
+        isConnectable={true}
+        id={Position.Right}
+      />
+      <Handle
+        type='target'
+        position={Position.Top}
+        isConnectable={true}
+        id={Position.Top}
+      />
+      <Handle
+        type='target'
+        position={Position.Left}
+        id={Position.Left}
+        // style={handleStyle}
+        isConnectable={true}
+      />
+      <Handle
+        type='target'
+        position={Position.Bottom}
+        id={Position.Bottom}
+        isConnectable={true}
+      />
+      <div className='label-wrap'>
+        <label htmlFor='text'>Text : </label>
+        <input
+          id='text'
+          name='text'
+          onChange={onChange}
+          className='nodrag'
+          placeholder='내용을 입력해주세요.'
+        />
+      </div>
+      <Handle
+        type='source'
+        position={Position.Right}
+        isConnectable={true}
+        id={Position.Right}
+      />
+      <Handle
+        type='source'
+        position={Position.Top}
+        isConnectable={true}
+        id={Position.Top}
+      />
+      <Handle
+        type='source'
+        position={Position.Left}
+        id={Position.Left}
+        // style={handleStyle}
+        isConnectable={true}
+      />
+      <Handle
+        type='source'
+        position={Position.Bottom}
+        id={Position.Bottom}
+        isConnectable={true}
+      />
+    </Wrap>
+  );
+}
+
+const Wrap = styled.div`
+  width: fit-content;
+
+  & .label-wrap {
+    width: fit-content;
+    padding: 1rem;
+    background-color: red;
+  }
+`;
+
+export default TextUpdaterNode;

--- a/src/app/roadmap/create/page.tsx
+++ b/src/app/roadmap/create/page.tsx
@@ -1,0 +1,144 @@
+'use client';
+// eslint-disable-next-line simple-import-sort/imports
+import { useCallback, useEffect, useState } from 'react';
+import ReactFlow, {
+  Background,
+  BezierEdge,
+  Connection,
+  ConnectionLineType,
+  Controls,
+  Edge,
+  EdgeChange,
+  MiniMap,
+  Node,
+  NodeChange,
+  Panel,
+  ReactFlowProvider,
+  addEdge,
+  applyEdgeChanges,
+  applyNodeChanges,
+} from 'reactflow';
+
+import PanelItem from '@/app/roadmap/create/components/PanelControl';
+import TextUpdaterNode from '@/app/roadmap/create/components/reactFlow/custom/TextUpdaterNode';
+import { defaultEdges, defaultNodes, edgeOptions } from '@/constants';
+import { CustomEdge, CustomNode } from '../post/components/roadmapInfo';
+
+const proOptions = { hideAttribution: true };
+
+const nodeTypes = { textUpdater: TextUpdaterNode };
+const edgeTypes = { bezierEdge: BezierEdge };
+
+const Flow = () => {
+  const [nodes, setNodes] = useState<Node[]>([]);
+  const [edges, setEdges] = useState(defaultEdges);
+
+  const onAddNode = useCallback(() => {
+    let nodeId = Number(nodes[nodes.length - 1]?.id) || 0;
+
+    const id = `${++nodeId}`;
+    const newNode = {
+      id,
+      data: { label: '내용을 입력해주세요.' },
+      position: {
+        x: nodes[nodes.length - 1]?.position?.x + 100 || 0,
+        y: nodes[nodes.length - 1]?.position?.y + 100 || 0,
+        zoom: 0.45,
+      },
+      positionAbsolute: {
+        x: nodes[nodes.length - 1]?.position?.x + 100 || 0,
+        y: nodes[nodes.length - 1]?.position?.y + 100 || 0,
+      },
+      type: 'textUpdater',
+      style: {
+        background: '#f4e9bc',
+        border: '1px solid black',
+        borderRadius: 15,
+        fontSize: 24,
+      },
+      blogKeyword: '',
+      detailedContent: '',
+    } as Node | CustomNode;
+
+    const temp = [...nodes, newNode] as Node[];
+    setNodes(temp);
+  }, [setNodes, nodes]);
+
+  const onConnect = useCallback(
+    (connection: Connection) => {
+      const edge = {
+        ...connection,
+        type: 'smoothstep',
+        id: `reactflow__edge-${connection.sourceHandle}${connection.source}-${connection.targetHandle}${connection.target}`,
+        sourceHandle: connection.sourceHandle,
+        targetHandle: connection.targetHandle,
+      } as Edge | Connection | CustomEdge;
+      setEdges((eds) => {
+        return addEdge(edge, eds);
+      });
+    },
+    [setEdges],
+  );
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      setNodes((nds) => applyNodeChanges(changes, nds));
+    },
+    [setNodes],
+  );
+
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) =>
+      setEdges((eds) => applyEdgeChanges(changes, eds)),
+    [setEdges],
+  );
+
+  useEffect(() => {
+    const temp = defaultNodes as Node[];
+    setNodes(temp);
+  }, []);
+
+  return (
+    <div
+      style={{
+        width: '100vw',
+        height: '96vh',
+        backgroundColor: '#0d0729',
+      }}
+    >
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        defaultEdgeOptions={edgeOptions}
+        connectionLineStyle={{ stroke: edgeOptions.style.stroke }}
+        fitView
+        zoomOnDoubleClick
+        elevateNodesOnSelect
+        snapToGrid
+        connectionLineType={ConnectionLineType.SmoothStep}
+        proOptions={proOptions}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        // onNodeClick={(e) => console.log('node click', e)}
+      >
+        <Panel position='top-right'>
+          <PanelItem onAddNode={onAddNode} nodes={nodes} edges={edges} />
+        </Panel>
+        <Background gap={16} />
+        <Controls position='bottom-right' />
+        <MiniMap zoomable pannable position='bottom-left' />
+      </ReactFlow>
+    </div>
+  );
+};
+
+export default function RoadmapEditorPage() {
+  return (
+    <ReactFlowProvider>
+      <Flow />
+    </ReactFlowProvider>
+  );
+}

--- a/src/app/roadmap/editor/page.tsx
+++ b/src/app/roadmap/editor/page.tsx
@@ -1,1 +1,0 @@
-export default function EditPage() {}

--- a/src/app/roadmap/post/components/comment/Comments.tsx
+++ b/src/app/roadmap/post/components/comment/Comments.tsx
@@ -56,7 +56,7 @@ const Comments = () => {
     queryFn: loadDataFromApi,
     initialPageParam: 1,
     getNextPageParam: ({ comments }) => {
-      const { next } = comments! as CommentData;
+      const { next } = (comments! as CommentData) || null;
       const pageNum = getPageNum(next);
       return pageNum;
     },

--- a/src/app/roadmap/post/components/roadmapInfo/index.tsx
+++ b/src/app/roadmap/post/components/roadmapInfo/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { ReactElement } from 'react';
+import { Connection } from 'reactflow';
 
 import { Member, Post } from '@/components/MainPage';
 
@@ -10,7 +10,6 @@ import { getApiResponse } from '@/utils/shared/get-api-response';
 
 import About from './About';
 import ReactFlow from './reactFlow/ReactFlow';
-
 export interface Position {
   x: number;
   y: number;
@@ -18,13 +17,15 @@ export interface Position {
 export interface Viewport extends Position {
   zoom: number;
 }
-export interface CustomEdge {
+export interface CustomEdge extends Connection {
   id: string;
   source: string;
   type: string;
+  style?: { stroke: string };
   animated: boolean;
 }
-export interface NodeStyle extends ReactElement {
+
+export interface NodeStyle {
   background: string;
   border: string;
   borderRadius: number;
@@ -32,19 +33,20 @@ export interface NodeStyle extends ReactElement {
 }
 export interface CustomNode {
   id: string;
-  type: string;
-  width: number;
-  height: number;
-  sourcePosition: string;
-  targetPosition: string;
-  done: boolean;
-  detailedContent: string;
-  style: NodeStyle;
   data: {
     label: string;
   };
-  position: Position;
-  positionAbsolute: Position;
+  position: Viewport | Position;
+  positionAbsolute?: Viewport | Position;
+  type: string;
+  sourcePosition?: string | null;
+  targetPosition?: string | null;
+  style: NodeStyle;
+  width?: number;
+  height?: number;
+  done?: boolean;
+  detailedContent?: string;
+  blogKeyword?: string;
 }
 
 export interface RoadMapInfo extends Post {

--- a/src/app/roadmap/post/components/roadmapInfo/reactFlow/custom/BezierEdge.tsx
+++ b/src/app/roadmap/post/components/roadmapInfo/reactFlow/custom/BezierEdge.tsx
@@ -1,6 +1,6 @@
 import { BaseEdge, EdgeProps, getBezierPath } from 'reactflow';
 
-export default function CustomEdge({
+export default function CustomBezierEdge({
   id,
   sourceX,
   sourceY,
@@ -18,9 +18,5 @@ export default function CustomEdge({
     targetPosition,
   });
 
-  return (
-    <>
-      <BaseEdge id={id} path={edgePath} />
-    </>
-  );
+  return <BaseEdge id={id} path={edgePath} />;
 }

--- a/src/app/roadmap/post/components/roadmapInfo/reactFlow/custom/DoneStatusNode.tsx
+++ b/src/app/roadmap/post/components/roadmapInfo/reactFlow/custom/DoneStatusNode.tsx
@@ -18,11 +18,55 @@ export function DoneStatusNode({ data }: NodeProps<NodeData>) {
         padding: '1rem',
       }}
     >
-      <Handle style={{ opacity: 0 }} type='target' position={Position.Left} />
-      <Handle style={{ opacity: 0 }} type='target' position={Position.Top} />
+      <Handle
+        style={{ opacity: 0 }}
+        type='target'
+        position={Position.Right}
+        id={Position.Right}
+      />
+      <Handle
+        style={{ opacity: 0 }}
+        type='target'
+        position={Position.Bottom}
+        id={Position.Bottom}
+      />
+      <Handle
+        style={{ opacity: 0 }}
+        type='target'
+        position={Position.Left}
+        id={Position.Left}
+      />
+      <Handle
+        style={{ opacity: 0 }}
+        type='target'
+        position={Position.Top}
+        id={Position.Top}
+      />
       {data.label}
-      <Handle style={{ opacity: 0 }} type='source' position={Position.Right} />
-      <Handle style={{ opacity: 0 }} type='source' position={Position.Bottom} />
+      <Handle
+        style={{ opacity: 0 }}
+        type='source'
+        position={Position.Left}
+        id={Position.Left}
+      />
+      <Handle
+        style={{ opacity: 0 }}
+        type='source'
+        position={Position.Right}
+        id={Position.Right}
+      />
+      <Handle
+        style={{ opacity: 0 }}
+        type='source'
+        position={Position.Bottom}
+        id={Position.Bottom}
+      />
+      <Handle
+        style={{ opacity: 0 }}
+        type='source'
+        position={Position.Top}
+        id={Position.Top}
+      />
     </Wrap>
   );
 }

--- a/src/app/roadmap/post/components/roadmapInfo/reactFlow/nodeDetail/TiptapEditor.tsx
+++ b/src/app/roadmap/post/components/roadmapInfo/reactFlow/nodeDetail/TiptapEditor.tsx
@@ -9,7 +9,7 @@ import { TextAlign } from '@tiptap/extension-text-align';
 import TextStyle from '@tiptap/extension-text-style';
 import { Underline } from '@tiptap/extension-underline';
 import Youtube from '@tiptap/extension-youtube';
-import { useEditor } from '@tiptap/react';
+import { Content, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { PropsWithChildren, useMemo } from 'react';
 
@@ -42,7 +42,8 @@ const NodeDetails = ({ details }: NodeDetailsProps) => {
   });
 
   useMemo(() => {
-    editor?.commands.setContent(details.detailedContent);
+    const content = details.detailedContent as Content;
+    editor?.commands.setContent(content);
   }, [details, editor?.commands]);
 
   return (

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -69,7 +69,7 @@ export default function Mainpage() {
     queryFn: loadDataFromApi,
     initialPageParam: 1,
     getNextPageParam: ({ postData }) => {
-      const { next } = postData! as Postdata;
+      const { next } = (postData! as Postdata) || null;
       const pageNum = getPageNum(next);
       return pageNum;
     },

--- a/src/components/shared/layouts/PageHeader.tsx
+++ b/src/components/shared/layouts/PageHeader.tsx
@@ -10,6 +10,9 @@ const PageHeader = () => {
       <button type='button' onClick={() => router.push('/auth')}>
         sign in
       </button>
+      <button type='button' onClick={() => router.push('/roadmap/create')}>
+        create roadmap
+      </button>
     </section>
   );
 };

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -4,7 +4,4 @@ export const SITE_CONFIG = {
   url: 'http://roadmaker.site',
 };
 
-export const HIDE_DEBUG_ARY = [
-  'getApiResponse',
-  // 'getMongoDbApiData',
-];
+export const HIDE_DEBUG_ARY = ['getApiResponse'];

--- a/src/constants/default/edges.ts
+++ b/src/constants/default/edges.ts
@@ -1,0 +1,25 @@
+import { Connection, Edge } from 'reactflow';
+
+import { CustomEdge } from '@/app/roadmap/post/components/roadmapInfo';
+
+export const edgeType = 'smoothstep';
+
+export const edgeOptions = {
+  animated: true,
+  style: {
+    stroke: '#D3D2E5',
+  },
+};
+
+export const defaultEdges: Edge<CustomEdge | Edge | Connection>[] = [
+  {
+    animated: true,
+    id: 'reactflow__edge-bottom1-top2',
+    source: '1',
+    sourceHandle: 'bottom',
+    style: { stroke: '#D3D2E5' },
+    target: '2',
+    targetHandle: 'top',
+    type: 'smoothstep',
+  },
+];

--- a/src/constants/default/nodes.ts
+++ b/src/constants/default/nodes.ts
@@ -1,0 +1,35 @@
+import { CustomNode } from '@/app/roadmap/post/components/roadmapInfo';
+
+export const defaultNodes: CustomNode[] = [
+  {
+    id: '1',
+    data: { label: '내용을 입력해주세요.' },
+    position: { x: 100, y: 100 },
+    type: 'textUpdater',
+    style: {
+      background: '#f4b4b4',
+      border: '1px solid black',
+      borderRadius: 15,
+      fontSize: 24,
+    },
+
+    blogKeyword: '',
+    detailedContent: '',
+  },
+  {
+    id: '2',
+    data: { label: '내용을 입력해주세요.' },
+    position: { x: 100, y: 200 },
+    positionAbsolute: { x: 100, y: 200 },
+    type: 'textUpdater',
+    style: {
+      background: '#f4e9bc',
+      border: '1px solid black',
+      borderRadius: 15,
+      fontSize: 24,
+    },
+
+    blogKeyword: '',
+    detailedContent: '',
+  },
+];

--- a/src/constants/default/viewport.ts
+++ b/src/constants/default/viewport.ts
@@ -1,0 +1,1 @@
+export const defaultViewport = { x: 0, y: 0, zoom: 0.45 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,5 @@
-export * from './config';
-export * from './env';
+export * from '@/constants/config';
+export * from '@/constants/default/edges';
+export * from '@/constants/default/nodes';
+export * from '@/constants/default/viewport';
+export * from '@/constants/env';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,7 +1650,7 @@
     react-textarea-autosize "8.5.3"
     type-fest "^3.13.1"
 
-"@mantine/dropzone@^7.5.2":
+"@mantine/dropzone@^7.6.1":
   version "7.6.1"
   resolved "https://registry.yarnpkg.com/@mantine/dropzone/-/dropzone-7.6.1.tgz#4fc53d0e5542b8c9e8e1918a669036aeeafe9538"
   integrity sha512-qkj681fV5DmCPW44PBhS5cKB2iYtU3UsEWA2VfC2vizU5FpSqFRF8qmaiH6OXyPYzeDK0X+IaEjUma1pqB5ZWA==


### PR DESCRIPTION
# Description & Technical Solution

- 이전 로드메이커에서 mantine dropzone을 활용하여 드롭한 이미지를 업로드하여 썸네일로 등록하는 동작에서 아래와 같이 무수한 요청이 계속 보내지는 버그가 있었습니다.
<img width="742" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/410193d1-1a7f-4d16-974d-d79bc0d31f83"/>
- 이 문제는 onDrop을 하는 동안 계속 실행되었고, 드롭존 모달을 닫지 않는 이상 무한 요청을 보냈습니다.
- 아래와 같이 fileDrop을 할 때는 files state만 변경하도록 하고,  files 의존성만 변경할 때 값을 변경하도록 `useMemo`를 통해 formData state을 업데이트하도록 했습니다.

```tsx


  const [files, setFiles] = useState<FileWithPath[]>([]);
  const [formData, setFormData] = useState<FormData | null>();

  useMemo(() => {
    const tempFormData = new FormData();
    tempFormData.append('file', files[0]);
    setFormData(tempFormData);
  }, [files]);

// 미리보기
  const previews = files.map((file, index) => {
    const imageUrl = URL.createObjectURL(file);
    return (
      <Image
        key={index}
        src={imageUrl}
        alt={imageUrl}
        onLoad={() => URL.revokeObjectURL(imageUrl)}
      />
    );
  });
// ...

 <Dropzone
          accept={IMAGE_MIME_TYPE}
          onDrop={(e) => {
            setFiles(e);
          }}
        >
          <Text ta='center'>Drop images here</Text>
 </Dropzone>
```
- 이전에는 handle (노드 연결 부분)이 좌우 또는 상하로만 가능했지만, `/PanelControl.tsx`에서 위 아래 핸들을 추가해줘서 모든 방향에서 연결 가능하도록 했습니다.
- `/DoneStatusNode.tsx`에서도 마찬가지로 id와 핸들들을 모두 추가해줬습니다
- 다음으로는 아래와 같이 데이터를 추가할 때 targetPosition 과 sourcePosition에 대한 데이터를 추가해서 해당 핸들 위치를 파악할 수 있도록 했습니다.

```tsx
    const tempNodes = nodes.reduce((acc, curr) => {
      const tempNodes = {
        ...omit(
          curr,
          'dragging',
          'selected',
          'type',
          'targetPosition',
          'sourcePosition',
        ),
        blogKeyword: '',
        detailedContent: '',
        type: 'custom',
        targetPosition: curr?.targetPosition || 'left',
        sourcePosition: curr?.sourcePosition || 'right',
        positionAbsolute: { x: curr.position.x, y: curr.position.y },
      } as CustomNode;
      if (acc.length !== 0) acc = [...acc, tempNodes];
      else acc = [tempNodes];
      return acc;
    }, [] as CustomNode[]);

```

- 마지막으로 로드맵 상세페이지에서 핸들 위치를 반영하기 위해, 아래와 같이 정규표현식을 활용해 핸들 시작과 끝 (sourceHandle & targetHandle)이 있는 지 확인하여 그려줬습니다.
- 다만, 마이그레이션 이전의 버전은 노드를 핸들 정보를 담고 있지 않기 때문에 일괄적으로 한쌍의 핸들만 갖습니다.

```tsx
  useEffect(() => {
    const customNodes = nodes as unknown as Node<Node[], string | undefined>[];
    const customEdges = edges.reduce(
      (acc, curr) => {
        const temp = curr;
        const regex = /left|right|top|bottom/g;
        const handles = temp.id.match(regex);

        if (handles) {
          temp['sourceHandle'] = `${handles[0]}`;
          temp['targetHandle'] = `${handles[1]}`;
        }
        acc.push(temp);

        return acc;
      },
      [] as Array<CustomEdge | Edge>,
    ) as Array<Edge>;

    setNodes(customNodes);
    setEdges(customEdges);
  }, [nodes, edges, setEdges, setNodes]);
```


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

## Screenshots

<img width="822" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/f265b425-6752-4ef2-bdd9-2cb553ec7597"/>

- 현재는 css스타일링이 들어가지 않는 버전입니다!!
- 아래는 아래의 기능적인 면에만 초점을 맞춘 상태입니다.
   - 로드맵 
      - 노드
      - 추가
      - 삭제
      - label수정
      - 노드 이어주는 기능
  - 썸네일 추가/제목 추가

<img width="617" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/f7a328a1-a8f4-45ef-bd61-467907d68970">
