### PR TITLE
fix: remove bad state in child component

### DIFF
--- a/src/app/roadmap/create/components/Flow.tsx
+++ b/src/app/roadmap/create/components/Flow.tsx
@@ -1,0 +1,163 @@
+'use client';
+import { Dispatch, SetStateAction, useCallback, useEffect } from 'react';
+import ReactFlow, {
+  addEdge,
+  applyEdgeChanges,
+  applyNodeChanges,
+  Background,
+  Connection,
+  ConnectionLineType,
+  Controls,
+  Edge,
+  EdgeChange,
+  MiniMap,
+  Node,
+  NodeChange,
+  Panel,
+} from 'reactflow';
+
+import CustomBezierEdge from '@/components/reactflow/custom/edge/BezierEdge';
+import TextUpdaterNode from '@/components/reactflow/custom/node/TextUpdaterNode';
+
+import {
+  defaultEdges,
+  defaultNodes,
+  edgeOptions,
+  randomNodeColor,
+} from '@/constants';
+
+import PanelItem from './panel/PanelControl';
+
+import { CustomEdge, CustomNode } from '@/types/reactFlow';
+
+const proOptions = { hideAttribution: true };
+
+const nodeTypes = { textUpdater: TextUpdaterNode };
+const edgeTypes = { bezierEdge: CustomBezierEdge };
+
+const Flow = ({
+  nodes,
+  edges,
+  setNodes,
+  setEdges,
+  setIsOpen,
+  setClickedNode,
+}: {
+  nodes: Node[];
+  edges: Edge<CustomEdge | Connection | Edge>[];
+  setNodes: Dispatch<SetStateAction<Node[]>>;
+  setEdges: Dispatch<SetStateAction<Edge<CustomEdge | Connection | Edge>[]>>;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  setClickedNode: Dispatch<SetStateAction<Node | null>>;
+}) => {
+  const onAddNode = useCallback(() => {
+    let nodeId = Number(nodes[nodes.length - 1]?.id) || 0;
+    const randomColorPickerIndex = Math.floor(
+      Math.random() * randomNodeColor.length,
+    );
+    const id = `${++nodeId}`;
+    const newNode = {
+      id,
+      data: { label: '내용을 입력해주세요.' },
+      position: {
+        x: nodes[nodes.length - 1]?.position?.x + 100 || 0,
+        y: nodes[nodes.length - 1]?.position?.y + 100 || 0,
+        zoom: 0.45,
+      },
+      positionAbsolute: {
+        x: nodes[nodes.length - 1]?.position?.x + 100 || 0,
+        y: nodes[nodes.length - 1]?.position?.y + 100 || 0,
+      },
+      type: 'textUpdater',
+      style: {
+        background: randomNodeColor[randomColorPickerIndex],
+        border: '1px solid black',
+        borderRadius: 15,
+        fontSize: 24,
+      },
+      blogKeyword: '',
+      detailedContent: '',
+    } as Node | CustomNode;
+
+    const temp = [...nodes, newNode] as Node[];
+    setNodes(temp);
+  }, [setNodes, nodes]);
+
+  const onConnect = useCallback(
+    (connection: Connection) => {
+      const edge = {
+        ...connection,
+        type: 'smoothstep',
+        id: `reactflow__edge-${connection.sourceHandle}${connection.source}-${connection.targetHandle}${connection.target}`,
+        sourceHandle: connection.sourceHandle,
+        targetHandle: connection.targetHandle,
+      } as Edge | Connection | CustomEdge;
+      setEdges((eds) => {
+        return addEdge(edge, eds);
+      });
+    },
+    [setEdges],
+  );
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      setNodes((nds) => applyNodeChanges(changes, nds));
+    },
+    [setNodes],
+  );
+
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) =>
+      setEdges((eds) => applyEdgeChanges(changes, eds)),
+    [setEdges],
+  );
+
+  useEffect(() => {
+    const tempNodes = defaultNodes as Node[];
+    const tempEdge = defaultEdges as Edge[];
+    setNodes(tempNodes);
+    setEdges(tempEdge);
+  }, [setNodes, setEdges]);
+
+  return (
+    <div
+      style={{
+        width: '100vw',
+        height: '96vh',
+        backgroundColor: '#EFEFEF',
+      }}
+    >
+      <ReactFlow
+        fitView
+        defaultEdgeOptions={edgeOptions}
+        connectionLineType={ConnectionLineType.SmoothStep}
+        connectionLineStyle={{ stroke: edgeOptions.style.stroke }}
+        nodes={nodes}
+        nodeTypes={nodeTypes}
+        edges={edges}
+        edgeTypes={edgeTypes}
+        proOptions={proOptions}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        zoomOnDoubleClick
+        elevateNodesOnSelect
+        snapToGrid
+        onConnect={onConnect}
+        onNodeClick={(e, node: Node) => {
+          setClickedNode(node);
+          if ('className' in e.target && e.target?.className === 'label-wrap')
+            setIsOpen(true);
+        }}
+      >
+        <Panel position='top-right'>
+          <PanelItem onAddNode={onAddNode} nodes={nodes} edges={edges} />
+        </Panel>
+        <Background gap={16} />
+        <Controls position='bottom-right' />
+        <MiniMap zoomable pannable position='bottom-left' />
+      </ReactFlow>
+    </div>
+  );
+};
+
+export default Flow;

--- a/src/app/roadmap/create/components/panel/items/NodeColorPicker.tsx
+++ b/src/app/roadmap/create/components/panel/items/NodeColorPicker.tsx
@@ -8,7 +8,6 @@ import { omit } from '@/utils/shared';
 
 const NodeColorPicker = ({
   clickedNode,
-  setClickedNode,
   setNodes,
   nodes,
 }: {
@@ -51,7 +50,6 @@ const NodeColorPicker = ({
             style: newStyle,
           } as Node;
 
-          setClickedNode(temp);
           const newNodes = nodes.reduce((acc, curr) => {
             if (curr.id === temp.id) {
               acc.push(temp);

--- a/src/app/roadmap/create/page.tsx
+++ b/src/app/roadmap/create/page.tsx
@@ -1,209 +1,85 @@
 'use client';
 
-// eslint-disable-next-line simple-import-sort/imports
 import { Box, Drawer, ScrollArea } from '@mantine/core';
 import { IconCircleChevronRight } from '@tabler/icons-react';
-import { useCallback, useEffect, useState } from 'react';
-import ReactFlow, {
-  Background,
-  BezierEdge,
-  Connection,
-  ConnectionLineType,
-  Controls,
-  Edge,
-  EdgeChange,
-  MiniMap,
-  Node,
-  NodeChange,
-  Panel,
-  ReactFlowProvider,
-  addEdge,
-  applyEdgeChanges,
-  applyNodeChanges,
-} from 'reactflow';
+import { useState } from 'react';
+import { Edge, Node, ReactFlowProvider } from 'reactflow';
 
-import TextUpdaterNode from '@/components/reactflow/custom/edge/TextUpdaterNode';
-
-import {
-  defaultEdges,
-  defaultNodes,
-  edgeOptions,
-  randomNodeColor,
-} from '@/constants';
-
-import DetailContentEditor from './components/panel/DetailContentEditor';
-import NodeColorPicker from './components/panel/NodeColorPicker';
-import PanelItem from './components/panel/PanelControl';
-
-import { CustomEdge, CustomNode } from '@/types/reactFlow';
-
-const proOptions = { hideAttribution: true };
-
-const nodeTypes = { textUpdater: TextUpdaterNode };
-const edgeTypes = { bezierEdge: BezierEdge };
-
-const Flow = () => {
-  const [nodes, setNodes] = useState<Node[]>([]);
-  const [edges, setEdges] = useState(defaultEdges);
-  const [isOpen, setIsOpen] = useState(false);
-
-  const [clickedNode, setClickedNode] = useState<Node | null>(null);
-
-  const onAddNode = useCallback(() => {
-    let nodeId = Number(nodes[nodes.length - 1]?.id) || 0;
-    const randomColorPickerIndex = Math.floor(
-      Math.random() * randomNodeColor.length,
-    );
-    const id = `${++nodeId}`;
-    const newNode = {
-      id,
-      data: { label: '내용을 입력해주세요.' },
-      position: {
-        x: nodes[nodes.length - 1]?.position?.x + 100 || 0,
-        y: nodes[nodes.length - 1]?.position?.y + 100 || 0,
-        zoom: 0.45,
-      },
-      positionAbsolute: {
-        x: nodes[nodes.length - 1]?.position?.x + 100 || 0,
-        y: nodes[nodes.length - 1]?.position?.y + 100 || 0,
-      },
-      type: 'textUpdater',
-      style: {
-        background: randomNodeColor[randomColorPickerIndex],
-        border: '1px solid black',
-        borderRadius: 15,
-        fontSize: 24,
-      },
-      blogKeyword: '',
-      detailedContent: '',
-    } as Node | CustomNode;
-
-    const temp = [...nodes, newNode] as Node[];
-    setNodes(temp);
-  }, [setNodes, nodes]);
-
-  const onConnect = useCallback(
-    (connection: Connection) => {
-      const edge = {
-        ...connection,
-        type: 'smoothstep',
-        id: `reactflow__edge-${connection.sourceHandle}${connection.source}-${connection.targetHandle}${connection.target}`,
-        sourceHandle: connection.sourceHandle,
-        targetHandle: connection.targetHandle,
-      } as Edge | Connection | CustomEdge;
-      setEdges((eds) => {
-        return addEdge(edge, eds);
-      });
-    },
-    [setEdges],
-  );
-
-  const onNodesChange = useCallback(
-    (changes: NodeChange[]) => {
-      setNodes((nds) => applyNodeChanges(changes, nds));
-    },
-    [setNodes],
-  );
-
-  const onEdgesChange = useCallback(
-    (changes: EdgeChange[]) =>
-      setEdges((eds) => applyEdgeChanges(changes, eds)),
-    [setEdges],
-  );
-
-  useEffect(() => {
-    const temp = defaultNodes as Node[];
-    setNodes(temp);
-  }, []);
-
-  return (
-    <div
-      style={{
-        width: '100vw',
-        height: '96vh',
-        backgroundColor: '#EFEFEF',
-      }}
-    >
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        defaultEdgeOptions={edgeOptions}
-        connectionLineStyle={{ stroke: edgeOptions.style.stroke }}
-        fitView
-        zoomOnDoubleClick
-        elevateNodesOnSelect
-        snapToGrid
-        connectionLineType={ConnectionLineType.SmoothStep}
-        proOptions={proOptions}
-        nodeTypes={nodeTypes}
-        edgeTypes={edgeTypes}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        onConnect={onConnect}
-        onNodeClick={(e, node: Node) => {
-          setClickedNode(node);
-          setIsOpen(true);
-        }}
-      >
-        <Panel position='top-right'>
-          <PanelItem onAddNode={onAddNode} nodes={nodes} edges={edges} />
-        </Panel>
-        <Drawer.Root
-          opened={isOpen}
-          scrollAreaComponent={ScrollArea.Autosize}
-          onClose={() => {
-            setIsOpen(false);
-          }}
-          position='right'
-          keepMounted
-          closeOnEscape
-          lockScroll={false}
-        >
-          <Drawer.Content>
-            <Drawer.CloseButton
-              mr='1rem'
-              mt='1rem'
-              ml='1rem'
-              icon={<IconCircleChevronRight size={26} stroke={1.5} />}
-            />
-            <Drawer.Body p='1rem' style={{ height: '100vh' }}>
-              {clickedNode && (
-                <Box pb='sm'>
-                  <Box pb='sm'>
-                    <Box py='sm'>노드 색상 변경</Box>
-                    <NodeColorPicker
-                      clickedNode={clickedNode}
-                      setClickedNode={setClickedNode}
-                      setNodes={setNodes}
-                      nodes={nodes}
-                    />
-                  </Box>
-                  <Box mt='sm'>
-                    <Box py='sm'>노드 상세 내용</Box>
-                    <DetailContentEditor
-                      clickedNode={clickedNode}
-                      setClickedNode={setClickedNode}
-                      setNodes={setNodes}
-                      nodes={nodes}
-                    />
-                  </Box>
-                </Box>
-              )}
-            </Drawer.Body>
-          </Drawer.Content>
-        </Drawer.Root>
-        <Background gap={16} />
-        <Controls position='bottom-right' />
-        <MiniMap zoomable pannable position='bottom-left' />
-      </ReactFlow>
-    </div>
-  );
-};
+import Flow from './components/Flow';
+import DetailContentEditor from './components/panel/items/DetailContentEditor';
+import NodeColorPicker from './components/panel/items/NodeColorPicker';
 
 export default function RoadmapEditorPage() {
+  const [nodes, setNodes] = useState<Node[]>([]);
+  const [edges, setEdges] = useState<Edge[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [clickedNode, setClickedNode] = useState<Node | null>(null);
+
   return (
     <ReactFlowProvider>
-      <Flow />
+      <Flow
+        nodes={nodes}
+        setNodes={setNodes}
+        edges={edges}
+        setEdges={setEdges}
+        setIsOpen={setIsOpen}
+        setClickedNode={setClickedNode}
+      />
+      <Drawer.Root
+        opened={isOpen}
+        scrollAreaComponent={ScrollArea.Autosize}
+        onClose={() => {
+          setIsOpen(false);
+        }}
+        position='right'
+        keepMounted
+        closeOnEscape
+        lockScroll={false}
+      >
+        <Drawer.Content>
+          <Drawer.CloseButton
+            mr='1rem'
+            mt='1rem'
+            ml='1rem'
+            icon={<IconCircleChevronRight size={26} stroke={1.5} />}
+          />
+          <Drawer.Body p='1rem' style={{ height: '100vh' }}>
+            {clickedNode && (
+              <Box pb='sm'>
+                <Box pb='sm'>
+                  <Box py='sm'>노드 색상 변경</Box>
+                  <NodeColorPicker
+                    clickedNode={clickedNode}
+                    setClickedNode={setClickedNode}
+                    setNodes={setNodes}
+                    nodes={nodes}
+                  />
+                </Box>
+                {/* 
+                  // 백엔드 api 변경 필요!
+                  <Box mt='sm'>
+                    <Box py='sm'>노드 모양 변경</Box>
+                    <NodeShapePicker
+                      clickedNode={clickedNode}
+                      setClickedNode={setClickedNode}
+                      setNodes={setNodes}
+                      nodes={nodes}
+                    />
+                  </Box> */}
+                <Box mt='sm'>
+                  <Box py='sm'>노드 상세 내용</Box>
+                  <DetailContentEditor
+                    clickedNode={clickedNode}
+                    setClickedNode={setClickedNode}
+                    setNodes={setNodes}
+                    nodes={nodes}
+                  />
+                </Box>
+              </Box>
+            )}
+          </Drawer.Body>
+        </Drawer.Content>
+      </Drawer.Root>
     </ReactFlowProvider>
   );
 }

--- a/src/components/reactflow/custom/node/TextUpdaterNode.tsx
+++ b/src/components/reactflow/custom/node/TextUpdaterNode.tsx
@@ -31,7 +31,6 @@ function TextUpdaterNode({ data }: Readonly<{ data: Node['data'] }>) {
         type='target'
         position={Position.Left}
         id={Position.Left}
-        // style={handleStyle}
         isConnectable={true}
       />
       <Handle
@@ -66,7 +65,6 @@ function TextUpdaterNode({ data }: Readonly<{ data: Node['data'] }>) {
         type='source'
         position={Position.Left}
         id={Position.Left}
-        // style={handleStyle}
         isConnectable={true}
       />
       <Handle


### PR DESCRIPTION
# Description & Technical Solution

- #39 해결을 위해 자식 컴포넌트에서 변경되었던 자식의 state와 부모의 state를, 자식 state을 제거하고 부모의 state를 props로 전달했습니다. 

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.
