### PR TITLE
fix: disable editor opening on textArea click

### DIFF
--- a/src/components/reactflow/custom/node/QuadroHandleNode.tsx
+++ b/src/components/reactflow/custom/node/QuadroHandleNode.tsx
@@ -44,7 +44,7 @@ export function QuadroHandleNode({ data }: NodeProps<NodeData>) {
         position={Position.Top}
         id={Position.Top}
       />
-      <Text>{data.label}</Text>
+      <Text className='label-input'>{data.label}</Text>
       <Handle
         style={{ opacity: 0 }}
         type='source'


### PR DESCRIPTION
# Description & Technical Solution

- 아래와 같이 클릭한 노드의 클래스명이 `label-wrap`인 경우에만 노드의 detailContentEditor가 열리도록 했습니다.
- 해당 클래스명은 textArea를 감싸고 있는 노드 영역이므로, textArea를 클릭해도 모달이 열리지 않습니다.
```tsx
   onNodeClick={(e, node: Node) => {
          setClickedNode(node);
          if ('className' in e.target && e.target?.className === 'label-wrap')
            setIsOpen(true);
        }}
```

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] Already rebased against main branch.

## Screenshots

Provide screenshots or videos of the changes made if any.
