### PR TITLE
feat: add auto layouting buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@tiptap/react": "^2.2.4",
     "@tiptap/starter-kit": "^2.2.4",
     "dayjs": "^1.11.10",
+    "elkjs": "^0.9.2",
     "embla-carousel-react": "^8.0.0-rc22",
     "lodash.debounce": "^4.0.8",
     "next": "14.1.0",
@@ -68,6 +69,7 @@
     "recharts": "2",
     "styled-components": "^6.1.8",
     "styled-reset": "^4.5.2",
+    "use-undoable": "^5.0.0",
     "zod": "^3.22.4",
     "zustand": "^4.5.0"
   },

--- a/src/types/elk.d.ts
+++ b/src/types/elk.d.ts
@@ -1,0 +1,96 @@
+declare module 'elkjs/lib/elk-api' {
+  export interface LayoutOptions {
+    [key: string]: string;
+  }
+
+  export interface ElkPoint {
+    x: number;
+    y: number;
+  }
+
+  export interface ElkGraphElement {
+    id: string;
+    labels?: ElkLabel[];
+    layoutOptions?: LayoutOptions;
+  }
+
+  export interface ElkShape extends ElkGraphElement {
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+  }
+
+  export interface ElkNode extends ElkShape {
+    children?: ElkNode[];
+    ports?: ElkPort[];
+    edges?: ElkEdge[];
+  }
+
+  export interface ElkPort extends ElkShape {}
+
+  export interface ElkLabel extends ElkShape {
+    text: string;
+  }
+
+  export interface ElkEdge extends ElkGraphElement {
+    junctionPoints?: ElkPoint[];
+  }
+
+  export interface ElkPrimitiveEdge extends ElkEdge {
+    source: string;
+    sourcePort?: string;
+    target: string;
+    targetPort?: string;
+    sourcePoint?: ElkPoint;
+    targetPoint?: ElkPoint;
+    bendPoints?: ElkPoint[];
+  }
+
+  export interface ElkExtendedEdge extends ElkEdge {
+    sources: string[];
+    targets: string[];
+    sections: ElkEdgeSection[];
+  }
+
+  export interface ElkEdgeSection extends ElkGraphElement {
+    startPoint: ElkPoint;
+    endPoint: ElkPoint;
+    bendPoints?: ElkPoint[];
+    incomingShape?: string;
+    outgoingShape?: string;
+    incomingSections?: string[];
+    outgoingSections?: string[];
+  }
+
+  export interface ELKLayoutArguments {
+    layoutOptions?: LayoutOptions;
+  }
+
+  export interface ELK {
+    layout(graph: ElkNode, args?: ELKLayoutArguments): Promise<ElkNode>;
+  }
+
+  export interface ELKConstructorArguments {
+    defaultLayoutOptions?: LayoutOptions;
+    algorithms?: string[];
+    workerUrl?: string;
+  }
+
+  const elk: {
+    new (args?: ELKConstructorArguments): ELK;
+  };
+  export default elk;
+}
+
+declare module 'elkjs' {
+  export * from 'elkjs/lib/elk-api';
+  import elk from 'elkjs/lib/elk-api';
+  export default elk;
+}
+
+declare module 'elkjs/lib/elk.bundled' {
+  export * from 'elkjs/lib/elk-api';
+  import elk from 'elkjs/lib/elk-api';
+  export default elk;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4104,6 +4104,11 @@ electron-to-chromium@^1.4.668:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.705.tgz#ef4f912620bd7c9555a20554ffc568184c0ddceb"
   integrity sha512-LKqhpwJCLhYId2VVwEzFXWrqQI5n5zBppz1W9ehhTlfYU8CUUW6kClbN8LHF/v7flMgRdETS772nqywJ+ckVAw==
 
+elkjs@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/elkjs/-/elkjs-0.9.2.tgz#3d4ef6f17fde06a5d7eaa3063bb875e25e59e972"
+  integrity sha512-2Y/RaA1pdgSHpY0YG4TYuYCD2wh97CRvu22eLG3Kz0pgQ/6KbIFTxsTnDc4MH/6hFlg2L/9qXrDMG0nMjP63iw==
+
 embla-carousel-react@^8.0.0-rc22:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/embla-carousel-react/-/embla-carousel-react-8.0.0.tgz#73abd0a30c2faa37532ae3c4c0b484867e066d5f"
@@ -8248,6 +8253,11 @@ use-sync-external-store@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
+use-undoable@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/use-undoable/-/use-undoable-5.0.0.tgz#e8aee660e7e9830c78e93551d5df471dfaddaf56"
+  integrity sha512-CGlysuqDYqhvKdC2Y+NX1KZhxtIDRyxaaYOuEVovspbqfTdRmvDjYQh0rtNA7ibSSL31jT4dh0PSJRtR6fB+xw==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
# Description & Technical Solution
- `elkjs` 라이브러리를 활용하여 자동 조정 버튼들을 통해 다음과 같은 기능을 구현했습니다.
1. 노드 간 간격 : 노드 내용을 변경할 수 있게 되어 크기에 따라 노드 간 겹침이 빌생할 수 있는 상황이어서, 일일히 수동으로 겹침을 조정하는 대신 버튼 클릭으로 간격이 조정되도록 했습니다.
2. 레이아웃 세로 조정
3. 레이아웃 가로 조정

- 레이아웃이 사용자가 원하는 방식과 다를 경우를 대비하여 `use-undoable` 라이브러리를 활용해 되돌리기 기능을 추가했습니다.
1. 사용자가 한 동작은 바로 이전 동작들이 차례로 되돌리기됩니다.
2. 자동레이아웃과 같은 경우는 동작 하나가 아닌 결과물이 되돌리기 됩니다.
3. 다시 실행하기 기능도 위와 마찬가지로 동작하지만, 되돌리기 했던 동작을 재실행한다는 점에서 다릅니다.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

## Screenshots

- 가로 레이아웃 적용 전
<img width="610" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/d8342fd5-cd56-4671-8e4b-27c90b39b9e2">

- 가로 레이아웃 적용 후
<img width="610" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/b3902b2d-3e49-48b9-8cb7-1aaabf2c7518">

- 세로 레이아웃 적용 후
<img width="610" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/27e86c16-5c98-4daa-adb4-68da42ae2b61">

- 되돌리기
<img width="610" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/f4ef371d-5773-4798-9218-d545e2b57d27">
 
- 되돌리기 취소
<img width="610" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/5c39055c-03cd-4ef6-85d8-d3af9dcb0e22">

- 노드 간 간격 조정 이전
<img width="610" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/4fec95db-0e97-4891-97f8-6e129b9269e1">

- 노드 간 간격 조정 이후
<img width="610" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/ffa14c14-7551-4878-8d80-c5dd2b3343ec">


