### PR TITLE
50-fix_multiple_requests_firing_upon_thumbnail_drop

### DIFF
--- a/src/app/roadmap/create/components/Flow.tsx
+++ b/src/app/roadmap/create/components/Flow.tsx
@@ -96,8 +96,7 @@ const Flow = ({
   }, [setNodes, nodes]);
 
   const useLayoutedElements = () => {
-    const { getNodes, setNodes, getEdges, fitView, setEdges, getViewport } =
-      useReactFlow();
+    const { getNodes, setNodes, getEdges, fitView, setEdges } = useReactFlow();
 
     const getLayoutedElements = useCallback(
       (options: { [key: string]: unknown }) => {
@@ -117,30 +116,32 @@ const Flow = ({
         elk.layout(graph).then(({ children, edges }) => {
           if (children) {
             const chrn = children as CustomElkNode[];
-
             chrn.forEach((node) => {
               node.position = { x: node.x, y: node.y } as XYPosition;
             });
             setNodes(chrn);
           }
+
           if (edges) {
             const eds = edges as unknown as Edge[];
             eds.forEach((edge) => {
               let temp = edge.id;
-              if (options['elk.direction'] === 'RIGHT') {
-                edge.sourceHandle = 'right';
-                edge.targetHandle = 'left';
-                temp = edge.id
-                  .replace('bottom', 'right')
-                  .replace('top', 'left');
-              } else if (options['elk.direction'] === 'DOWN') {
-                edge.sourceHandle = 'bottom';
-                edge.targetHandle = 'top';
-                temp = edge.id
-                  .replace('left', 'top')
-                  .replace('right', 'bottom');
+              if (options['elk.direction']) {
+                if (options['elk.direction'] === 'RIGHT') {
+                  edge.sourceHandle = 'right';
+                  edge.targetHandle = 'left';
+                  temp = edge.id
+                    .replace('bottom', 'right')
+                    .replace('top', 'left');
+                } else if (options['elk.direction'] === 'DOWN') {
+                  edge.sourceHandle = 'bottom';
+                  edge.targetHandle = 'top';
+                  temp = edge.id
+                    .replace('left', 'top')
+                    .replace('right', 'bottom');
+                }
+                edge.id = temp;
               }
-              edge.id = temp;
             });
 
             setEdges(eds);
@@ -151,8 +152,7 @@ const Flow = ({
           });
         });
       },
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [nodes, edges, getViewport],
+      [getNodes, getEdges, setNodes, setEdges, fitView],
     );
 
     return { getLayoutedElements };

--- a/src/app/roadmap/create/components/panel/PanelControl.tsx
+++ b/src/app/roadmap/create/components/panel/PanelControl.tsx
@@ -30,12 +30,12 @@ import {
   SetStateAction,
   useCallback,
   useMemo,
-  useRef,
   useState,
 } from 'react';
 import { Connection, Edge, Node } from 'reactflow';
 import useUndoable from 'use-undoable';
 
+import { apiRoutes } from '@/constants';
 import { omit } from '@/utils/shared';
 import { getApiResponse } from '@/utils/shared/get-api-response';
 
@@ -62,9 +62,11 @@ const PanelItem = ({
   const router = useRouter();
 
   const [files, setFiles] = useState<FileWithPath[]>([]);
+  const [thumbnail, setThumbnail] = useState(
+    localStorage.getItem('thumbnail') || null,
+  );
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const ref = useRef<HTMLImageElement | null>(null);
   const [formData, setFormData] = useState<FormData | null>();
   const [isToggled, setIsToggled] = useState(true);
   const [flow, setFlow, { undo, canUndo, redo, canRedo }] = useUndoable<{
@@ -89,18 +91,21 @@ const PanelItem = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [flow]);
 
-  const previews = files.map((file) => {
-    const imageUrl = URL.createObjectURL(file);
-    return (
-      <Image
-        ref={ref}
-        key={`${file.name}`}
-        src={imageUrl}
-        alt={imageUrl}
-        onLoad={() => URL.revokeObjectURL(imageUrl)}
-      />
-    );
-  });
+  const previews = useCallback(() => {
+    const url = thumbnail;
+    return files.map((file) => {
+      const imageUrl = URL.createObjectURL(file);
+
+      return (
+        <Image
+          key={`${file.name}`}
+          src={url}
+          alt={`${url}`}
+          onLoad={() => URL.revokeObjectURL(imageUrl)}
+        />
+      );
+    });
+  }, [files, thumbnail]);
 
   const onSubmitRoadmap = useCallback(async () => {
     if (!formData || !files) {
@@ -149,7 +154,7 @@ const PanelItem = ({
           edges: tempEdges,
           viewport: { x: 0, y: 0, zoom: 0.45 },
         }),
-        apiEndpoint: `${process.env.NEXT_PUBLIC_API}/roadmaps`,
+        apiEndpoint: `${apiRoutes.roadmaps}`,
         method: 'POST',
         headers: {
           Authorization: `Bearer ${process.env.NEXT_PUBLIC_USER_ACCESS_TOKEN}`,
@@ -165,7 +170,7 @@ const PanelItem = ({
     await Promise.all([
       getApiResponse<undefined>({
         requestData: formData,
-        apiEndpoint: `${process.env.NEXT_PUBLIC_API}/roadmaps/${response}/thumbnails`,
+        apiEndpoint: `${apiRoutes.roadmapsSlash}${response}/thumbnails`,
         method: 'POST',
         headers: {
           Authorization: `Bearer ${process.env.NEXT_PUBLIC_USER_ACCESS_TOKEN}`,
@@ -173,7 +178,7 @@ const PanelItem = ({
       }),
       getApiResponse<undefined>({
         requestData: JSON.stringify({}),
-        apiEndpoint: `${process.env.NEXT_PUBLIC_API}/roadmaps/${response}/join`,
+        apiEndpoint: `${apiRoutes.roadmapsSlash}${response}/join`,
         method: 'POST',
         headers: {
           Authorization: `Bearer ${process.env.NEXT_PUBLIC_USER_ACCESS_TOKEN}`,
@@ -181,6 +186,7 @@ const PanelItem = ({
         },
       }),
       alert(`${response} 포스팅 성공!`),
+      localStorage.removeItem('thumbnail'),
       router.replace(`/roadmap/post/${response}`),
     ]);
   }, [nodes, edges, files, title, description, formData, router]);
@@ -357,11 +363,18 @@ const PanelItem = ({
               accept={IMAGE_MIME_TYPE}
               onDrop={(e) => {
                 setFiles(e);
+                const fr = new FileReader();
+                fr.readAsDataURL(e[0]);
+                fr.onloadend = () => {
+                  const url = fr.result as string;
+                  localStorage.setItem('thumbnail', url);
+                  setThumbnail(url);
+                };
               }}
             >
-              {previews.length > 0 ? (
+              {files.length > 0 ? (
                 <Tooltip.Floating label='이미지 변경하기'>
-                  <Box>{previews}</Box>
+                  <Box>{previews()}</Box>
                 </Tooltip.Floating>
               ) : (
                 <Box

--- a/src/app/roadmap/post/[...id]/@comment/CommentBox.tsx
+++ b/src/app/roadmap/post/[...id]/@comment/CommentBox.tsx
@@ -18,6 +18,7 @@ import styled from 'styled-components';
 
 import TipTapTextEditor from '@/components/shared/tiptap/TipTapTextEditor';
 
+import { apiRoutes } from '@/constants';
 import { getApiResponse } from '@/utils/shared/get-api-response';
 
 const CommentBox = () => {
@@ -59,7 +60,7 @@ const CommentBox = () => {
           content: content,
           roadmapId: Number(currPostId[0]),
         }),
-        apiEndpoint: `${process.env.NEXT_PUBLIC_API}/comments`,
+        apiEndpoint: `${apiRoutes.comments}`,
         method: 'POST',
         headers: {
           Authorization: `Bearer ${process.env.NEXT_PUBLIC_USER_ACCESS_TOKEN}`,

--- a/src/app/roadmap/post/[...id]/@comment/Comments.tsx
+++ b/src/app/roadmap/post/[...id]/@comment/Comments.tsx
@@ -60,6 +60,7 @@ const Comments = () => {
     queryFn: loadDataFromApi,
     initialPageParam: 1,
     getNextPageParam: ({ comments }) => {
+      if (comments?.next) return getPageNum(null);
       const { next } = comments! || null;
       const pageNum = getPageNum(next);
       return pageNum;

--- a/src/app/roadmap/post/[...id]/@roadmapInfo/Likes.tsx
+++ b/src/app/roadmap/post/[...id]/@roadmapInfo/Likes.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
 import { PropsWithChildren, useMemo, useState } from 'react';
 
+import { apiRoutes } from '@/constants';
 import { omit, toTSXString } from '@/utils/shared';
 import { getApiResponse } from '@/utils/shared/get-api-response';
 
@@ -32,7 +33,8 @@ const Likes = ({ likesInfo }: LikeProps) => {
   const postResponseFromApi = async () => {
     const [likes] = await Promise.all([
       getApiResponse<LikeProps['likesInfo']>({
-        apiEndpoint: `${process.env.NEXT_PUBLIC_API}/likes/like-roadmap/${params.id}`,
+        // apiEndpoint: `${process.env.NEXT_PUBLIC_API}/like-roadmap/${params.id}`,
+        apiEndpoint: `${apiRoutes.likes}${params.id}`,
         method: 'POST',
         headers: {
           Authorization: `Bearer ${process.env.NEXT_PUBLIC_USER_ACCESS_TOKEN}`,
@@ -45,7 +47,7 @@ const Likes = ({ likesInfo }: LikeProps) => {
       setLikedCount(likes.likeCount);
       setHeartColor(likes.isLiked);
     }
-    // queryClient.invalidateQueries({ queryKey: [`post${params.id}`] });
+
     const previousData = queryClient.getQueryData([
       `post${params.id}`,
     ]) as RoadMapInfoQuery;
@@ -71,7 +73,6 @@ const Likes = ({ likesInfo }: LikeProps) => {
         style={{ color: 'red' }}
         onClick={postResponseFromApi}
       />
-      {/* {toTSXString(liked)} */}
       <Title order={6}>{toTSXString(likedCount)}</Title>
     </Box>
   );

--- a/src/app/roadmap/post/[...id]/@roadmapInfo/page.tsx
+++ b/src/app/roadmap/post/[...id]/@roadmapInfo/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 
 import { Member, Post } from '@/components/MainPage';
 
+import { apiRoutes } from '@/constants';
 import { omit, pick } from '@/utils/shared';
 import { getApiResponse } from '@/utils/shared/get-api-response';
 
@@ -35,7 +36,7 @@ export type aboutInfoKeys = keyof AboutInfo;
 const loadDataFromApi = async (pageParam: string) => {
   const [roadMapInfo] = await Promise.all([
     getApiResponse<RoadMapInfo>({
-      apiEndpoint: `${process.env.NEXT_PUBLIC_API}/roadmaps/${pageParam}`,
+      apiEndpoint: `${apiRoutes.roadmaps}/${pageParam}`,
       revalidate: 60 * 2, // 5 mins cache
     }),
   ]);

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,3 +3,4 @@ export * from '@/constants/default/edges';
 export * from '@/constants/default/nodes';
 export * from '@/constants/default/viewport';
 export * from '@/constants/env';
+export * from '@/constants/routes';

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,0 +1,7 @@
+export const apiRoutes = {
+  roadmaps: `${process.env.NEXT_PUBLIC_API}/roadmaps`,
+  roadmapsSlash: `${process.env.NEXT_PUBLIC_API}/roadmaps/`,
+  roadmapPaged: `${process.env.NEXT_PUBLIC_API}/roadmaps?page=`,
+  comments: `${process.env.NEXT_PUBLIC_API}/comments`,
+  likes: `${process.env.NEXT_PUBLIC_API}/likes/like-roadmap/`,
+};


### PR DESCRIPTION
# Description & Technical Solution

- 이전 로드메이커에서 mantine dropzone 컴포넌트를 활용해 이미지를 드롭했을 시 blob get 요청이 무수히 fire 되는 현상이 있었습니다.

<img width="953" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/5454414a-df48-40f6-aab4-c955479f8be5">

- 해당 문제는 아래와 같은 상황에서 반복적으로 발생했습니다. (#50)
    -  노드 드래그, 노드 상세 내용 수정
    -  dropzone에 이미지 로딩 중
 
- 초기 해결안 : useCallback으로 해당 이미지 컴포넌트를 감싸서, 업로드한 파일 (files)만 변경되었을 경우  함수를 재실행하도록 했습니다.
- 이로 인해서, 여러번 요청이 발생하는 문제는 해결되었지만, 드랍존은 토글이 가능한 panel 컴포넌트의 일부로, 해당 컴포넌트 토글을 닫았을 경우, 미리보기 이미지가 사라지고, path만 저장되는 문제가 있었습니다.

- 최종 해결안: 로컬스토리지를 활용하여, dropzone에 이미지를 드랍했을 경우 파일리더를 생성하고, 해당 이미지를 dataurl로 로컬 스토리지와 thumbnail이라는 state에 저장하고, thumbnail와 file을 useCallback의 의존성 배열에 추가하여 변경되었을 경우만 함수가 재실행되도록 했습니다.
- 

```tsx
\\ 드랍존에 이미지 드랍 시 로컬 스토리지에 데이터 url 저장
<Dropzone
              accept={IMAGE_MIME_TYPE}
              onDrop={(e) => {
                setFiles(e);
                const fr = new FileReader();
                fr.readAsDataURL(e[0]);
                fr.onloadend = () => {
                  const url = fr.result as string;
                  localStorage.setItem('thumbnail', url);
                  setThumbnail(url);
                };
              }}
            >
\\....
```

```tsx
 \\ 파일 배열과 위의 드랍존에서 로컬 스토리지에 저장했던 thumbnail이 변경되었을 시에만 미리보기 변경
  const previews = useCallback(() => {
    const url = thumbnail;
    return files.map((file) => {
      const imageUrl = URL.createObjectURL(file);

      return (
        <Image
          key={`${file.name}`}
          src={url}
          alt={`${url}`}
          onLoad={() => URL.revokeObjectURL(imageUrl)}
        />
      );
    });
  }, [files, thumbnail]);
```

```tsx
  const onSubmitRoadmap = useCallback(async () => {

  // ...중략...
 // 로드맵 생성 시 로컬 스토리지를 비워줍니다.
    await Promise.all([
      getApiResponse<undefined>({
        requestData: formData,
        apiEndpoint: `${apiRoutes.roadmapsSlash}${response}/thumbnails`,
        method: 'POST',
        headers: {
          Authorization: `Bearer ${process.env.NEXT_PUBLIC_USER_ACCESS_TOKEN}`,
        },
      }),
      getApiResponse<undefined>({
        requestData: JSON.stringify({}),
        apiEndpoint: `${apiRoutes.roadmapsSlash}${response}/join`,
        method: 'POST',
        headers: {
          Authorization: `Bearer ${process.env.NEXT_PUBLIC_USER_ACCESS_TOKEN}`,
          'Content-Type': 'application/json',
        },
      }),
      alert(`${response} 포스팅 성공!`),
      localStorage.removeItem('thumbnail'),
      router.replace(`/roadmap/post/${response}`),
    ]);
  }, [nodes, edges, files, title, description, formData, router]);

```

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

