### PR TITLE
55 fix heart like status not persisting

### DIFF
--- a/src/app/roadmap/post/[...id]/@roadmapInfo/Likes.tsx
+++ b/src/app/roadmap/post/[...id]/@roadmapInfo/Likes.tsx
@@ -29,12 +29,12 @@ const Likes = ({ likesInfo }: LikeProps) => {
   const [likedCount, setLikedCount] = useState(likesInfo.likeCount);
   const [liked, setLiked] = useState(likesInfo.isLiked);
   const params = useParams<{ tag: string; item: string; id: string[] }>();
-  const { data: token, status } = useSession();
+  const { data: session, status } = useSession();
 
   const queryClient = useQueryClient();
 
   const postResponseFromApi = async () => {
-    const accessToken = token as unknown as JWT;
+    const accessToken = session as unknown as JWT;
     const likes = await Promise.resolve(
       getApiResponse<LikeProps['likesInfo']>({
         apiEndpoint: `${apiRoutes.likes}${params.id}`,
@@ -49,7 +49,7 @@ const Likes = ({ likesInfo }: LikeProps) => {
     setLikedCount(likes.likeCount);
 
     const previousData = queryClient.getQueryData([
-      `post${params.id}`,
+      `post${params.id}-${accessToken?.user?.nickname}`,
     ]) as RoadMapInfoQuery;
 
     const newRoadMapInfo = {

--- a/src/app/roadmap/post/[...id]/@roadmapInfo/page.tsx
+++ b/src/app/roadmap/post/[...id]/@roadmapInfo/page.tsx
@@ -3,6 +3,9 @@
 import { Box } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
+import { JWT } from 'next-auth/jwt';
+import { useSession } from 'next-auth/react';
+import { useMemo, useState } from 'react';
 
 import { Member, Post } from '@/components/MainPage';
 
@@ -33,25 +36,77 @@ export type ReactFlowInfo = Pick<RoadMapInfo, AboutKeys>;
 
 export type aboutInfoKeys = keyof AboutInfo;
 
-const loadDataFromApi = async (pageParam: string) => {
-  const [roadMapInfo] = await Promise.all([
-    getApiResponse<RoadMapInfo>({
-      apiEndpoint: `${apiRoutes.roadmaps}/${pageParam}`,
-      revalidate: 60 * 2, // 5 mins cache
-    }),
-  ]);
-
-  return {
-    roadMapInfo,
-  };
-};
-
 const Roadmap = ({ params }: { params: { id: string } }) => {
   const { id } = params;
   const router = useRouter();
+  const { data: session, status } = useSession();
+
+  const [tokenState, setTokenState] = useState<JWT['token']>(null);
+
+  useMemo(() => {
+    const accessToken = session as unknown as JWT;
+    if (status !== 'loading') setTokenState(accessToken?.token);
+    // console.log(session);
+  }, [session, status]);
+
+  // const loadDataFromApi = async (pageParam: string) => {
+  //   let roadMapInfo;
+  //   if (tokenState) {
+  //     roadMapInfo = await Promise.resolve(
+  //       getApiResponse<RoadMapInfo>({
+  //         apiEndpoint: `${apiRoutes.roadmaps}/${pageParam}`,
+  //         revalidate: 60 * 2, // 5 mins cache
+  //         headers: {
+  //           Authorization: `Bearer ${tokenState}`,
+  //         },
+  //       }),
+  //     );
+  //   } else {
+  //     roadMapInfo = await Promise.resolve(
+  //       getApiResponse<RoadMapInfo>({
+  //         apiEndpoint: `${apiRoutes.roadmaps}/${pageParam}`,
+  //         revalidate: 60 * 2, // 5 mins cache
+  //       }),
+  //     );
+  //   }
+
+  //   return {
+  //     roadMapInfo,
+  //   };
+  // };
+
+  const loadDataFromApi = async (
+    pageParam: string,
+    tokenState: JWT['token'],
+  ) => {
+    let roadMapInfo;
+    if (tokenState) {
+      roadMapInfo = await Promise.resolve(
+        getApiResponse<RoadMapInfo>({
+          apiEndpoint: `${apiRoutes.roadmaps}/${pageParam}`,
+          revalidate: 60 * 2, // 5 mins cache
+          headers: {
+            Authorization: `Bearer ${tokenState}`,
+          },
+        }),
+      );
+    } else {
+      roadMapInfo = await Promise.resolve(
+        getApiResponse<RoadMapInfo>({
+          apiEndpoint: `${apiRoutes.roadmaps}/${pageParam}`,
+          revalidate: 60 * 2, // 5 mins cache
+        }),
+      );
+    }
+
+    return {
+      roadMapInfo,
+    };
+  };
+
   const { data, isLoading, isError, isSuccess } = useQuery({
     queryKey: [`post${id}`],
-    queryFn: async () => await loadDataFromApi(id),
+    queryFn: () => loadDataFromApi(id, tokenState),
   });
 
   if (isLoading) return <div>is loading</div>;
@@ -70,6 +125,7 @@ const Roadmap = ({ params }: { params: { id: string } }) => {
       'edges',
       'nodes',
     ) as ReactFlowInfo;
+
     const aboutInfo = omit(
       roadMapInfo,
       'viewport',

--- a/src/app/roadmap/post/[...id]/@roadmapInfo/page.tsx
+++ b/src/app/roadmap/post/[...id]/@roadmapInfo/page.tsx
@@ -43,42 +43,17 @@ const Roadmap = ({ params }: { params: { id: string } }) => {
 
   const [tokenState, setTokenState] = useState<JWT['token']>(null);
 
+  const [nickname, setNickname] = useState<JWT['user']['nickname']>(null);
+
   useMemo(() => {
     const accessToken = session as unknown as JWT;
-    if (status !== 'loading') setTokenState(accessToken?.token);
-    // console.log(session);
+    if (status !== 'loading') {
+      setTokenState(accessToken?.token);
+      setNickname(accessToken?.user?.nickname);
+    }
   }, [session, status]);
 
-  // const loadDataFromApi = async (pageParam: string) => {
-  //   let roadMapInfo;
-  //   if (tokenState) {
-  //     roadMapInfo = await Promise.resolve(
-  //       getApiResponse<RoadMapInfo>({
-  //         apiEndpoint: `${apiRoutes.roadmaps}/${pageParam}`,
-  //         revalidate: 60 * 2, // 5 mins cache
-  //         headers: {
-  //           Authorization: `Bearer ${tokenState}`,
-  //         },
-  //       }),
-  //     );
-  //   } else {
-  //     roadMapInfo = await Promise.resolve(
-  //       getApiResponse<RoadMapInfo>({
-  //         apiEndpoint: `${apiRoutes.roadmaps}/${pageParam}`,
-  //         revalidate: 60 * 2, // 5 mins cache
-  //       }),
-  //     );
-  //   }
-
-  //   return {
-  //     roadMapInfo,
-  //   };
-  // };
-
-  const loadDataFromApi = async (
-    pageParam: string,
-    tokenState: JWT['token'],
-  ) => {
+  const loadDataFromApi = async (pageParam: string) => {
     let roadMapInfo;
     if (tokenState) {
       roadMapInfo = await Promise.resolve(
@@ -105,8 +80,8 @@ const Roadmap = ({ params }: { params: { id: string } }) => {
   };
 
   const { data, isLoading, isError, isSuccess } = useQuery({
-    queryKey: [`post${id}`],
-    queryFn: () => loadDataFromApi(id, tokenState),
+    queryKey: [`post${id}-${nickname}`],
+    queryFn: async () => await loadDataFromApi(id),
   });
 
   if (isLoading) return <div>is loading</div>;

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -1,13 +1,21 @@
 declare module 'next-auth/jwt' {
   interface JWT extends DefaultJWT {
     user: {
-      id: string;
+      id: string | number;
       name?: string | null;
       email?: string | null;
       image?: string | null;
       message?: IAuthenticationErrror | null;
       user: Users | null;
       token?: string | null;
+      nickname?: string | null;
+      bio?: null | string;
+      avatarUrl?: null | string;
+      githubUrl?: null | string;
+      blogUrl?: null | string;
+      baekjoonId?: null | string;
+      provider?: string;
+      accessToken?: string;
     };
     token?: string | null;
   }


### PR DESCRIPTION
# Description & Technical Solution

- #55 좋아요 여부는 로그인 여부에 따라 header에 로그인 데이터를 보내집니다.
- 따라서, 현재 fetchquery를 할 경우, 이전에는 로그인을 나타낼 쿼리키가 반영되지 않아 좋아요 여부를 유지할 수 없었습니다.
- 아래와 같이 로드맵을 fetch할 시, 쿼리키에 사용자의 유저명을 추가하여 로그인 여부를 식별할 수 있도록 했습니다.

```tsx
  \\ ...중략
  const [nickname, setNickname] = useState<JWT['user']['nickname']>(null);

  useMemo(() => {
    const accessToken = session as unknown as JWT;
    if (status !== 'loading') {
      setTokenState(accessToken?.token);
      setNickname(accessToken?.user?.nickname);
    }
  }, [session, status]);
  \\ ...중략
  const { data, isLoading, isError, isSuccess } = useQuery({
    queryKey: [`post${id}-${nickname}`],
    queryFn: async () => await loadDataFromApi(id),
  });
```


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

## Screenshots

Provide screenshots or videos of the changes made if any.
