### PR TITLE
75-lcp_reduce

### DIFF
--- a/src/app/MainPage.tsx
+++ b/src/app/MainPage.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
+
+import PageFooter from '@/components/shared/layouts/PageFooter';
+import { SkeletonCardsGrid } from '@/components/shared/SkeletonGrid';
 
 import { API_ROUTES } from '@/constants';
 import { getApiResponse } from '@/utils/get-api-response';
 import { getPageNum } from '@/utils/shared';
 
 import { ItemsCardsGrid } from '../components/shared/ItemsCardsGrid';
-import { SkeletonCardsGrid } from '../components/shared/SkeletonGrid';
 
 import { Postdata } from '@/types/post';
 
@@ -62,24 +64,27 @@ export default function Mainpage() {
       </>
     );
   }
-  if (isLoading) return <SkeletonCardsGrid />;
-
+  // if (isLoading) return <SkeletonCardsGrid />;
+  if (isLoading) return <></>;
   if (posts)
     return (
       <main>
         <section>
-          {posts.pages.map(({ postData }, index) =>
-            postData?.next ? (
-              <ItemsCardsGrid
-                key={index}
-                postData={postData?.result}
-                innerRef={ref}
-              />
-            ) : (
-              <ItemsCardsGrid key={index} postData={postData?.result || []} />
-            ),
-          )}
+          <Suspense fallback={<SkeletonCardsGrid />}>
+            {posts.pages.map(({ postData }, index) =>
+              postData?.next ? (
+                <ItemsCardsGrid
+                  key={index}
+                  postData={postData?.result}
+                  innerRef={ref}
+                />
+              ) : (
+                <ItemsCardsGrid key={index} postData={postData?.result || []} />
+              ),
+            )}
+          </Suspense>
         </section>
+        {!hasNextPage && <PageFooter />}
       </main>
     );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,6 @@ import '@mantine/core/styles.css';
 import '@mantine/tiptap/styles.css';
 import 'reactflow/dist/style.css';
 
-import PageFooter from '@/components/shared/layouts/PageFooter';
 import PageHeader from '@/components/shared/layouts/PageHeader';
 
 import { SITE_CONFIG } from '@/constants';
@@ -64,7 +63,6 @@ export default function RootLayout({
             position='bottom-right'
           />
           {children}
-          <PageFooter />
         </Provider>
       </body>
     </html>

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -1,13 +1,18 @@
 import { Container } from '@mantine/core';
 
+import PageFooter from '@/components/shared/layouts/PageFooter';
+
 import { MyPageProps } from '@/types/user';
 
 const PostLayout = (props: MyPageProps) => {
   return (
-    <Container py='xl'>
-      <Container py='xl'>{props.info}</Container>
-      <Container py='xl'>{props.roadmaps}</Container>
-    </Container>
+    <>
+      <Container py='xl'>
+        <Container py='xl'>{props.info}</Container>
+        <Container py='xl'>{props.roadmaps}</Container>
+      </Container>
+      <PageFooter />
+    </>
   );
 };
 

--- a/src/components/shared/ItemCard.tsx
+++ b/src/components/shared/ItemCard.tsx
@@ -24,10 +24,10 @@ const ItemCard = ({
       >
         <AspectRatio ratio={1920 / 1080}>
           <Image
-            radius='md'
             src={article?.thumbnailUrl || null}
             alt={`${article?.thumbnailUrl} 이미지`}
             fallbackSrc='https://placehold.co/600x400?text=No Image'
+            loading='lazy'
           />
         </AspectRatio>
         <Text c='dimmed' size='xs' tt='uppercase' fw={700} mt='md'>
@@ -83,5 +83,10 @@ export const Wrap = styled.div`
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+  }
+
+  .card-img {
+    width: 6rem;
+    border-radius
   }
 `;

--- a/src/components/shared/Overlay.tsx
+++ b/src/components/shared/Overlay.tsx
@@ -1,21 +1,21 @@
 'use client';
-import { Box, LoadingOverlay } from '@mantine/core';
+import { LoadingOverlay } from '@mantine/core';
 
 import { theme } from '@/styles/theme';
 
 const OverLay = () => {
   return (
-    <Box pos='relative' h='100vh'>
-      <LoadingOverlay
-        visible={true}
-        zIndex={100000}
-        overlayProps={{ radius: 'sm', blur: 2 }}
-        loaderProps={{
-          color: theme.colors.color_grey2,
-          type: 'bars',
-        }}
-      />
-    </Box>
+    // <Box pos='relative' h='100vh'>
+    <LoadingOverlay
+      visible={true}
+      zIndex={100000}
+      overlayProps={{ radius: 'sm', blur: 2 }}
+      loaderProps={{
+        color: theme.colors.color_grey2,
+        type: 'bars',
+      }}
+    />
+    // </Box>
   );
 };
 export default OverLay;

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -96,11 +96,11 @@ export const GlobalStyle = createGlobalStyle`
 
 
 	.footer {
-  margin-top: rem(120px);
-  padding-top: calc(var(--mantine-spacing-xl) * 2);
-  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
-  border-top: rem(1px) solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
-}
+    margin-top: 2rem !important;
+    padding-top: calc(var(--mantine-spacing-xl) * 2);
+    background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
+    border-top: rem(1px) solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+  }
 
 .logo {
   max-width: rem(200px);
@@ -280,6 +280,7 @@ iframe {
   }
   .logo-img{
     width: 30px;
+    height: 30px;
   }
   .align-ctr{
     align-items: center ;


### PR DESCRIPTION
# Description & Technical Solution

- 성능 최적화를 위해 inline-css를 최소화했습니다. 
  - 다만 `ReactFlow.tsx `컴포넌트에서 로드맵을 그려주기 위해서는 반드시 픽셀로 계산한 높이가 필요합니다.
  - 노드의 최상과 최하단의 높이차의 데이터를 가지고  계산하기 위해서 인라인으로 width/height 스타일을 주었습니다.
- suspense로 로딩 중인 요소를 감싸주고 skeleton-ui로 fallback을 제공했습니다.
- 메인페이지의 무한 스크롤링으로 인해 푸터의 위치가 가변적인 현상이 발생합니다. 
 - 해당 문제로 인해 cumulative-layout-shift 척도가 나쁜 문제가 있습니다.
 - 따라서 이를 해결하기 위해 layout에서 footer 컴포넌트를 제거하고, 쿼리의hasNextPage가 false일 경우에만 해당 컴포넌트를 보이도록 했습니다.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

## Screenshots

<img width="424" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/6e8b76ef-d31c-45a7-92d3-11c583be0b0f">


<img width="424" alt="image" src="https://github.com/Pyotato/roadmaker_fe/assets/102423086/dfe39376-88b7-4445-9bef-9459cb27a1e5">

